### PR TITLE
gomaasapi: use a giant honking lock around all API calls

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -7,10 +7,11 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	. "gopkg.in/check.v1"
 	"net/http"
 	"net/url"
 	"strings"
+
+	. "gopkg.in/check.v1"
 )
 
 type ClientSuite struct{}

--- a/example/live_example.go
+++ b/example/live_example.go
@@ -11,8 +11,9 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/juju/gomaasapi"
 	"net/url"
+
+	"github.com/juju/gomaasapi"
 )
 
 var apiKey string

--- a/gomaasapi_test.go
+++ b/gomaasapi_test.go
@@ -4,8 +4,9 @@
 package gomaasapi
 
 import (
-	. "gopkg.in/check.v1"
 	"testing"
+
+	. "gopkg.in/check.v1"
 )
 
 func Test(t *testing.T) {

--- a/jsonobject_test.go
+++ b/jsonobject_test.go
@@ -6,6 +6,7 @@ package gomaasapi
 import (
 	"encoding/json"
 	"fmt"
+
 	. "gopkg.in/check.v1"
 )
 

--- a/maas_test.go
+++ b/maas_test.go
@@ -4,8 +4,9 @@
 package gomaasapi
 
 import (
-	. "gopkg.in/check.v1"
 	"net/url"
+
+	. "gopkg.in/check.v1"
 )
 
 type MAASSuite struct{}

--- a/maasobject_test.go
+++ b/maasobject_test.go
@@ -6,9 +6,10 @@ package gomaasapi
 import (
 	"encoding/json"
 	"fmt"
-	. "gopkg.in/check.v1"
 	"math/rand"
 	"net/url"
+
+	. "gopkg.in/check.v1"
 )
 
 type MAASObjectSuite struct{}

--- a/testservice_test.go
+++ b/testservice_test.go
@@ -18,8 +18,8 @@ import (
 	"strconv"
 	"strings"
 
-	"gopkg.in/mgo.v2/bson"
 	. "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2/bson"
 )
 
 type TestServerSuite struct {


### PR DESCRIPTION
The test server mock has a lot of mutable state, none of it guarded
by locks. It is possible to go through each field and check who uses
it, find all their methods, add locks, rinse, repeat.

Or, we could do something really dirty and serialise all API access
through one mutex. This has the obvious side effect that API calls
are no longer concurrent, but was their any promise of that before?
The change also has the effect that a memory barrier, covering all
the state in the test server structure, is asserted before and after
each API call

Also, a tonne of `gofmt`
