### PR TITLE
A post operation on a node now populates interfaces_set

### DIFF
--- a/testservice.go
+++ b/testservice.go
@@ -844,26 +844,18 @@ func nodeHandler(server *TestServer, w http.ResponseWriter, r *http.Request, sys
 		return
 	}
 	UUID, UUIDError := node.values["system_id"].GetString()
+	if UUIDError == nil {
+		i, err := JSONObjectFromStruct(server.client, server.nodeMetadata[UUID].Interfaces)
+		checkError(err)
+		node.values["interface_set"] = i
+	}
 
 	if r.Method == "GET" {
 		if operation == "" {
 			w.WriteHeader(http.StatusOK)
-			if UUIDError == nil {
-				i, err := JSONObjectFromStruct(server.client, server.nodeMetadata[UUID].Interfaces)
-				checkError(err)
-				if err == nil {
-					node.values["interface_set"] = i
-				}
-			}
 			fmt.Fprint(w, marshalNode(node))
 			return
 		} else if operation == "details" {
-			if UUIDError == nil {
-				i, err := JSONObjectFromStruct(server.client, server.nodeMetadata[UUID].Interfaces)
-				if err == nil {
-					node.values["interface_set"] = i
-				}
-			}
 			nodeDetailsHandler(server, w, r, systemId)
 			return
 		} else {

--- a/testservice_test.go
+++ b/testservice_test.go
@@ -1142,6 +1142,25 @@ func (suite *TestMAASObjectSuite) TestOperationsOnNode(c *C) {
 	}
 }
 
+func (suite *TestMAASObjectSuite) TestNodePostPopulatesInterfaces(c *C) {
+	server := suite.TestMAASObject.TestServer
+	input := `{"system_id": "mysystemid"}`
+	node := server.NewNode(input)
+	subnet := server.NewSubnet(subnetJSON(defaultSubnet()))
+	// Put the node in the subnet
+	var nni NodeNetworkInterface
+	nni.Name = "eth0"
+	nni.Links = append(nni.Links, NetworkLink{uint(1), "auto", subnet})
+	server.SetNodeNetworkLink("mysystemid", nni)
+	result, err := node.CallPost("start", url.Values{})
+	c.Assert(err, IsNil)
+	resultMap, err := result.GetMap()
+	c.Check(err, IsNil)
+	array, err := resultMap["interface_set"].GetArray()
+	c.Check(err, IsNil)
+	c.Check(array, HasLen, 1)
+}
+
 func (suite *TestMAASObjectSuite) TestOperationsOnNodeGetRecorded(c *C) {
 	input := `{"system_id": "mysystemid"}`
 	node := suite.TestMAASObject.TestServer.NewNode(input)


### PR DESCRIPTION
Fix the test server so that node interfaces_set is populated for all operations.
