### PR TITLE
Controller.AllocateMachine

### DIFF
--- a/bootresource.go
+++ b/bootresource.go
@@ -60,7 +60,7 @@ func readBootResources(controllerVersion version.Number, source interface{}) ([]
 	checker := schema.List(schema.StringMap(schema.Any()))
 	coerced, err := checker.Coerce(source, nil)
 	if err != nil {
-		return nil, errors.Annotatef(err, "boot resource base schema check failed")
+		return nil, WrapWithDeserializationError(err, "boot resource base schema check failed")
 	}
 	valid := coerced.([]interface{})
 
@@ -71,7 +71,7 @@ func readBootResources(controllerVersion version.Number, source interface{}) ([]
 		}
 	}
 	if deserialisationVersion == version.Zero {
-		return nil, errors.Errorf("no boot resource read func for version %s", controllerVersion)
+		return nil, NewUnsupportedVersionError("no boot resource read func for version %s", controllerVersion)
 	}
 	readFunc := bootResourceDeserializationFuncs[deserialisationVersion]
 	return readBootResourceList(valid, readFunc)
@@ -83,7 +83,7 @@ func readBootResourceList(sourceList []interface{}, readFunc bootResourceDeseria
 	for i, value := range sourceList {
 		source, ok := value.(map[string]interface{})
 		if !ok {
-			return nil, errors.Errorf("unexpected value for boot resource %d, %T", i, value)
+			return nil, NewDeserializationError("unexpected value for boot resource %d, %T", i, value)
 		}
 		bootResource, err := readFunc(source)
 		if err != nil {
@@ -113,7 +113,7 @@ func bootResource_2_0(source map[string]interface{}) (*bootResource, error) {
 	checker := schema.FieldMap(fields, nil) // no defaults
 	coerced, err := checker.Coerce(source, nil)
 	if err != nil {
-		return nil, errors.Annotatef(err, "boot resource 2.0 schema check failed")
+		return nil, WrapWithDeserializationError(err, "boot resource 2.0 schema check failed")
 	}
 	valid := coerced.(map[string]interface{})
 	// From here we know that the map returned from the schema coercion

--- a/bootresource_test.go
+++ b/bootresource_test.go
@@ -16,6 +16,7 @@ var _ = gc.Suite(&bootResourceSuite{})
 
 func (*bootResourceSuite) TestReadBootResourcesBadSchema(c *gc.C) {
 	_, err := readBootResources(twoDotOh, "wat?")
+	c.Check(err, jc.Satisfies, IsDeserializationError)
 	c.Assert(err.Error(), gc.Equals, `boot resource base schema check failed: expected list, got string("wat?")`)
 }
 
@@ -36,7 +37,7 @@ func (*bootResourceSuite) TestReadBootResources(c *gc.C) {
 
 func (*bootResourceSuite) TestLowVersion(c *gc.C) {
 	_, err := readBootResources(version.MustParse("1.9.0"), parseJSON(c, bootResourcesResponse))
-	c.Assert(err.Error(), gc.Equals, `no boot resource read func for version 1.9.0`)
+	c.Assert(err, jc.Satisfies, IsUnsupportedVersionError)
 }
 
 func (*bootResourceSuite) TestHighVersion(c *gc.C) {

--- a/client_test.go
+++ b/client_test.go
@@ -11,182 +11,188 @@ import (
 	"net/url"
 	"strings"
 
-	. "gopkg.in/check.v1"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 )
 
 type ClientSuite struct{}
 
-var _ = Suite(&ClientSuite{})
+var _ = gc.Suite(&ClientSuite{})
 
-func (*ClientSuite) TestReadAndCloseReturnsEmptyStringForNil(c *C) {
+func (*ClientSuite) TestReadAndCloseReturnsEmptyStringForNil(c *gc.C) {
 	data, err := readAndClose(nil)
-	c.Assert(err, IsNil)
-	c.Check(string(data), Equals, "")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(string(data), gc.Equals, "")
 }
 
-func (*ClientSuite) TestReadAndCloseReturnsContents(c *C) {
+func (*ClientSuite) TestReadAndCloseReturnsContents(c *gc.C) {
 	content := "Stream contents."
 	stream := ioutil.NopCloser(strings.NewReader(content))
 
 	data, err := readAndClose(stream)
-	c.Assert(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
-	c.Check(string(data), Equals, content)
+	c.Check(string(data), gc.Equals, content)
 }
 
-func (suite *ClientSuite) TestClientdispatchRequestReturnsServerError(c *C) {
+func (suite *ClientSuite) TestClientdispatchRequestReturnsServerError(c *gc.C) {
 	URI := "/some/url/?param1=test"
 	expectedResult := "expected:result"
 	server := newSingleServingServer(URI, expectedResult, http.StatusBadRequest)
 	defer server.Close()
 	client, err := NewAnonymousClient(server.URL, "1.0")
-	c.Assert(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	request, err := http.NewRequest("GET", server.URL+URI, nil)
 
 	result, err := client.dispatchRequest(request)
 
-	expectedErrorString := fmt.Sprintf("gomaasapi: got error back from server: 400 Bad Request (%v)", expectedResult)
-	c.Check(err.Error(), Equals, expectedErrorString)
-	c.Check(err.(ServerError).StatusCode, Equals, 400)
-	c.Check(string(result), Equals, expectedResult)
+	expectedErrorString := fmt.Sprintf("ServerError: 400 Bad Request (%v)", expectedResult)
+	c.Check(err.Error(), gc.Equals, expectedErrorString)
+
+	svrError, ok := GetServerError(err)
+	c.Assert(ok, jc.IsTrue)
+	c.Check(svrError.StatusCode, gc.Equals, 400)
+	c.Check(string(result), gc.Equals, expectedResult)
 }
 
-func (suite *ClientSuite) TestClientdispatchRequestRetries503(c *C) {
+func (suite *ClientSuite) TestClientdispatchRequestRetries503(c *gc.C) {
 	URI := "/some/url/?param1=test"
 	server := newFlakyServer(URI, 503, NumberOfRetries)
 	defer server.Close()
 	client, err := NewAnonymousClient(server.URL, "1.0")
-	c.Assert(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	content := "content"
 	request, err := http.NewRequest("GET", server.URL+URI, ioutil.NopCloser(strings.NewReader(content)))
 
 	_, err = client.dispatchRequest(request)
 
-	c.Check(err, IsNil)
-	c.Check(*server.nbRequests, Equals, NumberOfRetries+1)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(*server.nbRequests, gc.Equals, NumberOfRetries+1)
 	expectedRequestsContent := make([][]byte, NumberOfRetries+1)
 	for i := 0; i < NumberOfRetries+1; i++ {
 		expectedRequestsContent[i] = []byte(content)
 	}
-	c.Check(*server.requests, DeepEquals, expectedRequestsContent)
+	c.Check(*server.requests, jc.DeepEquals, expectedRequestsContent)
 }
 
-func (suite *ClientSuite) TestClientdispatchRequestDoesntRetry200(c *C) {
+func (suite *ClientSuite) TestClientdispatchRequestDoesntRetry200(c *gc.C) {
 	URI := "/some/url/?param1=test"
 	server := newFlakyServer(URI, 200, 10)
 	defer server.Close()
 	client, err := NewAnonymousClient(server.URL, "1.0")
-	c.Assert(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	request, err := http.NewRequest("GET", server.URL+URI, nil)
 
 	_, err = client.dispatchRequest(request)
 
-	c.Check(err, IsNil)
-	c.Check(*server.nbRequests, Equals, 1)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(*server.nbRequests, gc.Equals, 1)
 }
 
-func (suite *ClientSuite) TestClientdispatchRequestRetriesIsLimited(c *C) {
+func (suite *ClientSuite) TestClientdispatchRequestRetriesIsLimited(c *gc.C) {
 	URI := "/some/url/?param1=test"
 	// Make the server return 503 responses NumberOfRetries + 1 times.
 	server := newFlakyServer(URI, 503, NumberOfRetries+1)
 	defer server.Close()
 	client, err := NewAnonymousClient(server.URL, "1.0")
-	c.Assert(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	request, err := http.NewRequest("GET", server.URL+URI, nil)
 
 	_, err = client.dispatchRequest(request)
 
-	c.Check(*server.nbRequests, Equals, NumberOfRetries+1)
-	c.Check(err.(ServerError).StatusCode, Equals, 503)
+	c.Check(*server.nbRequests, gc.Equals, NumberOfRetries+1)
+	svrError, ok := GetServerError(err)
+	c.Assert(ok, jc.IsTrue)
+	c.Assert(svrError.StatusCode, gc.Equals, 503)
 }
 
-func (suite *ClientSuite) TestClientDispatchRequestReturnsNonServerError(c *C) {
+func (suite *ClientSuite) TestClientDispatchRequestReturnsNonServerError(c *gc.C) {
 	client, err := NewAnonymousClient("/foo", "1.0")
-	c.Assert(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	// Create a bad request that will fail to dispatch.
 	request, err := http.NewRequest("GET", "/", nil)
-	c.Assert(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := client.dispatchRequest(request)
-
+	c.Check(err, gc.NotNil)
 	// This type of failure is an error, but not a ServerError.
-	c.Check(err, NotNil)
-	c.Check(err, Not(FitsTypeOf), ServerError{})
+	_, ok := GetServerError(err)
+	c.Assert(ok, jc.IsFalse)
 	// For this kind of error, result is guaranteed to be nil.
-	c.Check(result, IsNil)
+	c.Check(result, gc.IsNil)
 }
 
-func (suite *ClientSuite) TestClientdispatchRequestSignsRequest(c *C) {
+func (suite *ClientSuite) TestClientdispatchRequestSignsRequest(c *gc.C) {
 	URI := "/some/url/?param1=test"
 	expectedResult := "expected:result"
 	server := newSingleServingServer(URI, expectedResult, http.StatusOK)
 	defer server.Close()
 	client, err := NewAuthenticatedClient(server.URL, "the:api:key", "1.0")
-	c.Assert(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	request, err := http.NewRequest("GET", server.URL+URI, nil)
-	c.Assert(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := client.dispatchRequest(request)
 
-	c.Check(err, IsNil)
-	c.Check(string(result), Equals, expectedResult)
-	c.Check((*server.requestHeader)["Authorization"][0], Matches, "^OAuth .*")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(string(result), gc.Equals, expectedResult)
+	c.Check((*server.requestHeader)["Authorization"][0], gc.Matches, "^OAuth .*")
 }
 
-func (suite *ClientSuite) TestClientGetFormatsGetParameters(c *C) {
+func (suite *ClientSuite) TestClientGetFormatsGetParameters(c *gc.C) {
 	URI, err := url.Parse("/some/url")
-	c.Assert(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := "expected:result"
 	params := url.Values{"test": {"123"}}
 	fullURI := URI.String() + "?test=123"
 	server := newSingleServingServer(fullURI, expectedResult, http.StatusOK)
 	defer server.Close()
 	client, err := NewAnonymousClient(server.URL, "1.0")
-	c.Assert(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := client.Get(URI, "", params)
 
-	c.Check(err, IsNil)
-	c.Check(string(result), Equals, expectedResult)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(string(result), gc.Equals, expectedResult)
 }
 
-func (suite *ClientSuite) TestClientGetFormatsOperationAsGetParameter(c *C) {
+func (suite *ClientSuite) TestClientGetFormatsOperationAsGetParameter(c *gc.C) {
 	URI, err := url.Parse("/some/url")
-	c.Assert(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := "expected:result"
 	fullURI := URI.String() + "?op=list"
 	server := newSingleServingServer(fullURI, expectedResult, http.StatusOK)
 	defer server.Close()
 	client, err := NewAnonymousClient(server.URL, "1.0")
-	c.Assert(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := client.Get(URI, "list", nil)
 
-	c.Check(err, IsNil)
-	c.Check(string(result), Equals, expectedResult)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(string(result), gc.Equals, expectedResult)
 }
 
-func (suite *ClientSuite) TestClientPostSendsRequestWithParams(c *C) {
+func (suite *ClientSuite) TestClientPostSendsRequestWithParams(c *gc.C) {
 	URI, err := url.Parse("/some/url")
-	c.Check(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := "expected:result"
 	fullURI := URI.String() + "?op=list"
 	params := url.Values{"test": {"123"}}
 	server := newSingleServingServer(fullURI, expectedResult, http.StatusOK)
 	defer server.Close()
 	client, err := NewAnonymousClient(server.URL, "1.0")
-	c.Check(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := client.Post(URI, "list", params, nil)
 
-	c.Check(err, IsNil)
-	c.Check(string(result), Equals, expectedResult)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(string(result), gc.Equals, expectedResult)
 	postedValues, err := url.ParseQuery(*server.requestContent)
-	c.Check(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	expectedPostedValues, err := url.ParseQuery("test=123")
-	c.Check(err, IsNil)
-	c.Check(postedValues, DeepEquals, expectedPostedValues)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(postedValues, jc.DeepEquals, expectedPostedValues)
 }
 
 // extractFileContent extracts from the request built using 'requestContent',
@@ -210,75 +216,75 @@ func extractFileContent(requestContent string, requestHeader *http.Header, reque
 	return fileContent, nil
 }
 
-func (suite *ClientSuite) TestClientPostSendsMultipartRequest(c *C) {
+func (suite *ClientSuite) TestClientPostSendsMultipartRequest(c *gc.C) {
 	URI, err := url.Parse("/some/url")
-	c.Assert(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := "expected:result"
 	fullURI := URI.String() + "?op=add"
 	server := newSingleServingServer(fullURI, expectedResult, http.StatusOK)
 	defer server.Close()
 	client, err := NewAnonymousClient(server.URL, "1.0")
-	c.Assert(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	fileContent := []byte("content")
 	files := map[string][]byte{"testfile": fileContent}
 
 	result, err := client.Post(URI, "add", nil, files)
 
-	c.Check(err, IsNil)
-	c.Check(string(result), Equals, expectedResult)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(string(result), gc.Equals, expectedResult)
 	receivedFileContent, err := extractFileContent(*server.requestContent, server.requestHeader, fullURI, "testfile")
-	c.Assert(err, IsNil)
-	c.Check(receivedFileContent, DeepEquals, fileContent)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(receivedFileContent, jc.DeepEquals, fileContent)
 }
 
-func (suite *ClientSuite) TestClientPutSendsRequest(c *C) {
+func (suite *ClientSuite) TestClientPutSendsRequest(c *gc.C) {
 	URI, err := url.Parse("/some/url")
-	c.Assert(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := "expected:result"
 	params := url.Values{"test": {"123"}}
 	server := newSingleServingServer(URI.String(), expectedResult, http.StatusOK)
 	defer server.Close()
 	client, err := NewAnonymousClient(server.URL, "1.0")
-	c.Assert(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := client.Put(URI, params)
 
-	c.Check(err, IsNil)
-	c.Check(string(result), Equals, expectedResult)
-	c.Check(*server.requestContent, Equals, "test=123")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(string(result), gc.Equals, expectedResult)
+	c.Check(*server.requestContent, gc.Equals, "test=123")
 }
 
-func (suite *ClientSuite) TestClientDeleteSendsRequest(c *C) {
+func (suite *ClientSuite) TestClientDeleteSendsRequest(c *gc.C) {
 	URI, err := url.Parse("/some/url")
-	c.Assert(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := "expected:result"
 	server := newSingleServingServer(URI.String(), expectedResult, http.StatusOK)
 	defer server.Close()
 	client, err := NewAnonymousClient(server.URL, "1.0")
-	c.Assert(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 
 	err = client.Delete(URI)
 
-	c.Check(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (suite *ClientSuite) TestNewAnonymousClientEnsuresTrailingSlash(c *C) {
+func (suite *ClientSuite) TestNewAnonymousClientEnsuresTrailingSlash(c *gc.C) {
 	client, err := NewAnonymousClient("http://example.com/", "1.0")
-	c.Check(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	expectedURL, err := url.Parse("http://example.com/api/1.0/")
-	c.Assert(err, IsNil)
-	c.Check(client.APIURL, DeepEquals, expectedURL)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(client.APIURL, jc.DeepEquals, expectedURL)
 }
 
-func (suite *ClientSuite) TestNewAuthenticatedClientEnsuresTrailingSlash(c *C) {
+func (suite *ClientSuite) TestNewAuthenticatedClientEnsuresTrailingSlash(c *gc.C) {
 	client, err := NewAuthenticatedClient("http://example.com/", "a:b:c", "1.0")
-	c.Check(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	expectedURL, err := url.Parse("http://example.com/api/1.0/")
-	c.Assert(err, IsNil)
-	c.Check(client.APIURL, DeepEquals, expectedURL)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(client.APIURL, jc.DeepEquals, expectedURL)
 }
 
-func (suite *ClientSuite) TestNewAuthenticatedClientParsesApiKey(c *C) {
+func (suite *ClientSuite) TestNewAuthenticatedClientParsesApiKey(c *gc.C) {
 	// NewAuthenticatedClient returns a plainTextOAuthSigneri configured
 	// to use the given API key.
 	consumerKey := "consumerKey"
@@ -289,24 +295,25 @@ func (suite *ClientSuite) TestNewAuthenticatedClientParsesApiKey(c *C) {
 
 	client, err := NewAuthenticatedClient("http://example.com/", apiKey, "1.0")
 
-	c.Check(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	signer := client.Signer.(*plainTextOAuthSigner)
-	c.Check(signer.token.ConsumerKey, Equals, consumerKey)
-	c.Check(signer.token.TokenKey, Equals, tokenKey)
-	c.Check(signer.token.TokenSecret, Equals, tokenSecret)
+	c.Check(signer.token.ConsumerKey, gc.Equals, consumerKey)
+	c.Check(signer.token.TokenKey, gc.Equals, tokenKey)
+	c.Check(signer.token.TokenSecret, gc.Equals, tokenSecret)
 }
 
-func (suite *ClientSuite) TestNewAuthenticatedClientFailsIfInvalidKey(c *C) {
+func (suite *ClientSuite) TestNewAuthenticatedClientFailsIfInvalidKey(c *gc.C) {
 	client, err := NewAuthenticatedClient("", "invalid-key", "1.0")
 
-	c.Check(err, ErrorMatches, "invalid API key.*")
-	c.Check(client, IsNil)
+	c.Check(err, gc.ErrorMatches, "invalid API key.*")
+	c.Check(client, gc.IsNil)
 
 }
 
-func (suite *ClientSuite) TestcomposeAPIURLReturnsURL(c *C) {
+func (suite *ClientSuite) TestcomposeAPIURLReturnsURL(c *gc.C) {
 	apiurl, err := composeAPIURL("http://example.com/MAAS", "1.0")
-	c.Assert(err, IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	expectedURL, err := url.Parse("http://example.com/MAAS/api/1.0/")
-	c.Check(expectedURL, DeepEquals, apiurl)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(expectedURL, jc.DeepEquals, apiurl)
 }

--- a/controller.go
+++ b/controller.go
@@ -60,7 +60,7 @@ func NewController(args ControllerArgs) (Controller, error) {
 				return nil, errors.Trace(err)
 			}
 			// Any other error attempting to create the authenticated client
-			// is an unexpeded error and return now.
+			// is an unexpected error and return now.
 			return nil, NewUnexpectedError(err)
 		}
 		controllerVersion := version.Number{

--- a/controller.go
+++ b/controller.go
@@ -5,6 +5,7 @@ package gomaasapi
 
 import (
 	"encoding/json"
+	"net/http"
 	"net/url"
 	"sync/atomic"
 
@@ -223,7 +224,7 @@ func (c *controller) AllocateMachine(args AllocateMachineArgs) (Machine, error) 
 	if err != nil {
 		// A 409 Status code is "No Matching Machines"
 		if svrErr, ok := errors.Cause(err).(ServerError); ok {
-			if svrErr.StatusCode == 409 {
+			if svrErr.StatusCode == http.StatusConflict {
 				return nil, errors.Wrap(err, NewNoMatchError(svrErr.BodyMessage))
 			}
 		}

--- a/controller_test.go
+++ b/controller_test.go
@@ -36,12 +36,12 @@ func (s *controllerSuite) SetUpTest(c *gc.C) {
 	s.CleanupSuite.SetUpTest(c)
 
 	server := NewSimpleServer()
-	server.AddResponse("/api/2.0/boot-resources/", http.StatusOK, bootResourcesResponse)
-	server.AddResponse("/api/2.0/fabrics/", http.StatusOK, fabricResponse)
-	server.AddResponse("/api/2.0/machines/", http.StatusOK, machinesResponse)
-	server.AddResponse("/api/2.0/spaces/", http.StatusOK, spacesResponse)
-	server.AddResponse("/api/2.0/version/", http.StatusOK, versionResponse)
-	server.AddResponse("/api/2.0/zones/", http.StatusOK, zoneResponse)
+	server.AddGetResponse("/api/2.0/boot-resources/", http.StatusOK, bootResourcesResponse)
+	server.AddGetResponse("/api/2.0/fabrics/", http.StatusOK, fabricResponse)
+	server.AddGetResponse("/api/2.0/machines/", http.StatusOK, machinesResponse)
+	server.AddGetResponse("/api/2.0/spaces/", http.StatusOK, spacesResponse)
+	server.AddGetResponse("/api/2.0/version/", http.StatusOK, versionResponse)
+	server.AddGetResponse("/api/2.0/zones/", http.StatusOK, zoneResponse)
 	server.Start()
 	s.AddCleanup(func(*gc.C) { server.Close() })
 	s.server = server
@@ -106,6 +106,14 @@ func (s *controllerSuite) TestMachines(c *gc.C) {
 	machines, err := controller.Machines(MachinesArgs{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.HasLen, 3)
+}
+
+func (s *controllerSuite) TestAllocateMachine(c *gc.C) {
+	s.server.AddPostResponse("/api/2.0/machines/?op=allocate", http.StatusOK, machineResponse)
+	controller := s.getController(c)
+	machine, err := controller.AllocateMachine(AllocateMachineArgs{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machine.SystemID(), gc.Equals, "4y3ha3")
 }
 
 var versionResponse = `{"version": "unknown", "subversion": "", "capabilities": ["networks-management", "static-ipaddresses", "ipv6-deployment-ubuntu", "devices-management", "storage-deployment-ubuntu", "network-deployment-ubuntu"]}`

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,97 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package gomaasapi
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+)
+
+// NoMatchError is returned when the requested action cannot be performed
+// due to being unable to service due to no entities available that match the
+// request.
+type NoMatchError struct {
+	errors.Err
+}
+
+// NewNoMatchError constructs a new NoMatchError and sets the location.
+func NewNoMatchError(message string) error {
+	err := &NoMatchError{Err: errors.NewErr(message)}
+	err.SetLocation(1)
+	return err
+}
+
+// IsNoMatchError returns true if err is a NoMatchError.
+func IsNoMatchError(err error) bool {
+	_, ok := errors.Cause(err).(*NoMatchError)
+	return ok
+}
+
+// UnexpectedError is an error for a condition that hasn't been determined.
+type UnexpectedError struct {
+	errors.Err
+}
+
+// NewUnexpectedError constructs a new UnexpectedError and sets the location.
+func NewUnexpectedError(err error) error {
+	uerr := &UnexpectedError{Err: errors.NewErr("unexpected: %v", err)}
+	uerr.SetLocation(1)
+	return errors.Wrap(err, uerr)
+}
+
+// IsUnexpectedError returns true if err is an UnexpectedError.
+func IsUnexpectedError(err error) bool {
+	_, ok := errors.Cause(err).(*UnexpectedError)
+	return ok
+}
+
+// UnsupportedVersionError refers to calls made to an unsupported api version.
+type UnsupportedVersionError struct {
+	errors.Err
+}
+
+// NewUnsupportedVersionError constructs a new UnsupportedVersionError and sets the location.
+func NewUnsupportedVersionError(format string, args ...interface{}) error {
+	err := &UnsupportedVersionError{Err: errors.NewErr(format, args...)}
+	err.SetLocation(1)
+	return err
+}
+
+// IsUnsupportedVersionError returns true if err is an UnsupportedVersionError.
+func IsUnsupportedVersionError(err error) bool {
+	_, ok := errors.Cause(err).(*UnsupportedVersionError)
+	return ok
+}
+
+// DeserializationError types are returned when the returned JSON data from
+// the controller doesn't match the code's expectations.
+type DeserializationError struct {
+	errors.Err
+}
+
+// NewDeserializationError constructs a new DeserializationError and sets the location.
+func NewDeserializationError(format string, args ...interface{}) error {
+	err := &DeserializationError{Err: errors.NewErr(format, args...)}
+	err.SetLocation(1)
+	return err
+}
+
+// WrapWithDeserializationError constructs a new DeserializationError with the
+// specified message, and sets the location and returns a new error with the
+// full error stack set including the error passed in.
+func WrapWithDeserializationError(err error, format string, args ...interface{}) error {
+	message := fmt.Sprintf(format, args...)
+	// We want the deserialization error message to include the error text of the
+	// previous error, but wrap it in the new type.
+	derr := &DeserializationError{Err: errors.NewErr(message + ": " + err.Error())}
+	derr.SetLocation(1)
+	return errors.Wrap(err, derr)
+}
+
+// IsDeserializationError returns true if err is a DeserializationError.
+func IsDeserializationError(err error) bool {
+	_, ok := errors.Cause(err).(*DeserializationError)
+	return ok
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,54 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package gomaasapi
+
+import (
+	"strings"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type errorTypesSuite struct{}
+
+var _ = gc.Suite(&errorTypesSuite{})
+
+func (*errorTypesSuite) TestNoMatchError(c *gc.C) {
+	err := NewNoMatchError("foo")
+	c.Assert(err, gc.NotNil)
+	c.Assert(err, jc.Satisfies, IsNoMatchError)
+}
+
+func (*errorTypesSuite) TestUnexpectedError(c *gc.C) {
+	err := errors.New("wat")
+	err = NewUnexpectedError(err)
+	c.Assert(err, gc.NotNil)
+	c.Assert(err, jc.Satisfies, IsUnexpectedError)
+	c.Assert(err.Error(), gc.Equals, "unexpected: wat")
+}
+
+func (*errorTypesSuite) TestUnsupportedVersionError(c *gc.C) {
+	err := NewUnsupportedVersionError("foo %d", 42)
+	c.Assert(err, gc.NotNil)
+	c.Assert(err, jc.Satisfies, IsUnsupportedVersionError)
+	c.Assert(err.Error(), gc.Equals, "foo 42")
+}
+
+func (*errorTypesSuite) TestDeserializationError(c *gc.C) {
+	err := NewDeserializationError("foo %d", 42)
+	c.Assert(err, gc.NotNil)
+	c.Assert(err, jc.Satisfies, IsDeserializationError)
+	c.Assert(err.Error(), gc.Equals, "foo 42")
+}
+
+func (*errorTypesSuite) TestWrapWithDeserializationError(c *gc.C) {
+	err := errors.New("base error")
+	err = WrapWithDeserializationError(err, "foo %d", 42)
+	c.Assert(err, gc.NotNil)
+	c.Assert(err, jc.Satisfies, IsDeserializationError)
+	c.Assert(err.Error(), gc.Equals, "foo 42: base error")
+	stack := errors.ErrorStack(err)
+	c.Assert(strings.Split(stack, "\n"), gc.HasLen, 2)
+}

--- a/interface.go
+++ b/interface.go
@@ -37,6 +37,8 @@ type Controller interface {
 
 	// Machines returns a list of machines that match the params.
 	Machines(MachinesArgs) ([]Machine, error)
+
+	AllocateMachine(AllocateMachineArgs) (Machine, error)
 }
 
 // Fabric represents a set of interconnected VLANs that are capable of mutual
@@ -109,7 +111,7 @@ type BootResource interface {
 
 // Machine represents a physical machine.
 type Machine interface {
-	SystemId() string
+	SystemID() string
 	Hostname() string
 	FQDN() string
 
@@ -117,7 +119,7 @@ type Machine interface {
 	DistroSeries() string
 	Architecture() string
 	Memory() int
-	CpuCount() int
+	CPUCount() int
 
 	IPAddresses() []string
 	PowerState() string
@@ -132,6 +134,7 @@ type Machine interface {
 	Zone() Zone
 }
 
+// MachinesArgs is a argument struct for selecting Machines.
 type MachinesArgs struct {
 	SystemIds []string
 }

--- a/machine.go
+++ b/machine.go
@@ -34,8 +34,8 @@ type machine struct {
 	zone *zone
 }
 
-// SystemId implements Machine.
-func (m *machine) SystemId() string {
+// SystemID implements Machine.
+func (m *machine) SystemID() string {
 	return m.systemID
 }
 
@@ -59,8 +59,8 @@ func (m *machine) Memory() int {
 	return m.memory
 }
 
-// CpuCount implements Machine.
-func (m *machine) CpuCount() int {
+// CPUCount implements Machine.
+func (m *machine) CPUCount() int {
 	return m.cpuCount
 }
 
@@ -99,14 +99,37 @@ func (m *machine) StatusMessage() string {
 	return m.statusMessage
 }
 
+func readMachine(controllerVersion version.Number, source interface{}) (*machine, error) {
+	readFunc, err := getMachineDeserializationFunc(controllerVersion)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	checker := schema.StringMap(schema.Any())
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "machine base schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+	return readFunc(valid)
+}
+
 func readMachines(controllerVersion version.Number, source interface{}) ([]*machine, error) {
+	readFunc, err := getMachineDeserializationFunc(controllerVersion)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	checker := schema.List(schema.StringMap(schema.Any()))
 	coerced, err := checker.Coerce(source, nil)
 	if err != nil {
 		return nil, errors.Annotatef(err, "machine base schema check failed")
 	}
 	valid := coerced.([]interface{})
+	return readMachineList(valid, readFunc)
+}
 
+func getMachineDeserializationFunc(controllerVersion version.Number) (machineDeserializationFunc, error) {
 	var deserialisationVersion version.Number
 	for v := range machineDeserializationFuncs {
 		if v.Compare(deserialisationVersion) > 0 && v.Compare(controllerVersion) <= 0 {
@@ -116,8 +139,7 @@ func readMachines(controllerVersion version.Number, source interface{}) ([]*mach
 	if deserialisationVersion == version.Zero {
 		return nil, errors.Errorf("no machine read func for version %s", controllerVersion)
 	}
-	readFunc := machineDeserializationFuncs[deserialisationVersion]
-	return readMachineList(valid, readFunc)
+	return machineDeserializationFuncs[deserialisationVersion], nil
 }
 
 func readMachineList(sourceList []interface{}, readFunc machineDeserializationFunc) ([]*machine, error) {

--- a/machine.go
+++ b/machine.go
@@ -108,7 +108,7 @@ func readMachine(controllerVersion version.Number, source interface{}) (*machine
 	checker := schema.StringMap(schema.Any())
 	coerced, err := checker.Coerce(source, nil)
 	if err != nil {
-		return nil, errors.Annotatef(err, "machine base schema check failed")
+		return nil, WrapWithDeserializationError(err, "machine base schema check failed")
 	}
 	valid := coerced.(map[string]interface{})
 	return readFunc(valid)
@@ -123,7 +123,7 @@ func readMachines(controllerVersion version.Number, source interface{}) ([]*mach
 	checker := schema.List(schema.StringMap(schema.Any()))
 	coerced, err := checker.Coerce(source, nil)
 	if err != nil {
-		return nil, errors.Annotatef(err, "machine base schema check failed")
+		return nil, WrapWithDeserializationError(err, "machine base schema check failed")
 	}
 	valid := coerced.([]interface{})
 	return readMachineList(valid, readFunc)
@@ -137,7 +137,7 @@ func getMachineDeserializationFunc(controllerVersion version.Number) (machineDes
 		}
 	}
 	if deserialisationVersion == version.Zero {
-		return nil, errors.Errorf("no machine read func for version %s", controllerVersion)
+		return nil, NewUnsupportedVersionError("no machine read func for version %s", controllerVersion)
 	}
 	return machineDeserializationFuncs[deserialisationVersion], nil
 }
@@ -147,7 +147,7 @@ func readMachineList(sourceList []interface{}, readFunc machineDeserializationFu
 	for i, value := range sourceList {
 		source, ok := value.(map[string]interface{})
 		if !ok {
-			return nil, errors.Errorf("unexpected value for machine %d, %T", i, value)
+			return nil, NewDeserializationError("unexpected value for machine %d, %T", i, value)
 		}
 		machine, err := readFunc(source)
 		if err != nil {
@@ -188,7 +188,7 @@ func machine_2_0(source map[string]interface{}) (*machine, error) {
 	checker := schema.FieldMap(fields, nil) // no defaults
 	coerced, err := checker.Coerce(source, nil)
 	if err != nil {
-		return nil, errors.Annotatef(err, "machine 2.0 schema check failed")
+		return nil, WrapWithDeserializationError(err, "machine 2.0 schema check failed")
 	}
 	valid := coerced.(map[string]interface{})
 	// From here we know that the map returned from the schema coercion

--- a/machine_test.go
+++ b/machine_test.go
@@ -32,12 +32,12 @@ func (*machineSuite) TestReadMachines(c *gc.C) {
 
 	machine := machines[0]
 
-	c.Check(machine.SystemId(), gc.Equals, "4y3ha3")
+	c.Check(machine.SystemID(), gc.Equals, "4y3ha3")
 	c.Check(machine.Hostname(), gc.Equals, "untasted-markita")
 	c.Check(machine.FQDN(), gc.Equals, "untasted-markita.maas")
 	c.Check(machine.IPAddresses(), jc.DeepEquals, []string{"192.168.100.4"})
 	c.Check(machine.Memory(), gc.Equals, 1024)
-	c.Check(machine.CpuCount(), gc.Equals, 1)
+	c.Check(machine.CPUCount(), gc.Equals, 1)
 	c.Check(machine.PowerState(), gc.Equals, "on")
 	c.Check(machine.Zone().Name(), gc.Equals, "default")
 	c.Check(machine.OperatingSystem(), gc.Equals, "ubuntu")

--- a/machine_test.go
+++ b/machine_test.go
@@ -15,6 +15,7 @@ var _ = gc.Suite(&machineSuite{})
 
 func (*machineSuite) TestReadMachinesBadSchema(c *gc.C) {
 	_, err := readMachines(twoDotOh, "wat?")
+	c.Check(err, jc.Satisfies, IsDeserializationError)
 	c.Assert(err.Error(), gc.Equals, `machine base schema check failed: expected list, got string("wat?")`)
 
 	_, err = readMachines(twoDotOh, []map[string]interface{}{
@@ -22,6 +23,7 @@ func (*machineSuite) TestReadMachinesBadSchema(c *gc.C) {
 			"wat": "?",
 		},
 	})
+	c.Check(err, jc.Satisfies, IsDeserializationError)
 	c.Assert(err, gc.ErrorMatches, `machine 0: machine 2.0 schema check failed: .*`)
 }
 
@@ -49,6 +51,7 @@ func (*machineSuite) TestReadMachines(c *gc.C) {
 
 func (*machineSuite) TestLowVersion(c *gc.C) {
 	_, err := readMachines(version.MustParse("1.9.0"), parseJSON(c, machinesResponse))
+	c.Assert(err, jc.Satisfies, IsUnsupportedVersionError)
 	c.Assert(err.Error(), gc.Equals, `no machine read func for version 1.9.0`)
 }
 
@@ -58,9 +61,9 @@ func (*machineSuite) TestHighVersion(c *gc.C) {
 	c.Assert(machines, gc.HasLen, 3)
 }
 
-var machinesResponse = `
-[
-    {
+const (
+	machineResponse = `
+	{
         "netboot": false,
         "system_id": "4y3ha3",
         "ip_addresses": [
@@ -305,7 +308,9 @@ var machinesResponse = `
             "ttl": null,
             "authoritative": true
         }
-    },
+    }
+`
+	machinesResponse = "[" + machineResponse + `,
     {
         "netboot": true,
         "system_id": "4y3ha4",
@@ -792,3 +797,4 @@ var machinesResponse = `
     }
 ]
 `
+)

--- a/urlparams.go
+++ b/urlparams.go
@@ -3,7 +3,10 @@
 
 package gomaasapi
 
-import "net/url"
+import (
+	"fmt"
+	"net/url"
+)
 
 // URLParams wraps url.Values to easily add values, but skipping empty ones.
 type URLParams struct {
@@ -19,6 +22,20 @@ func NewURLParams() *URLParams {
 func (p *URLParams) MaybeAdd(name, value string) {
 	if value != "" {
 		p.Values.Add(name, value)
+	}
+}
+
+// MaybeAddInt adds the (name, value) pair iff value is not zero.
+func (p *URLParams) MaybeAddInt(name string, value int) {
+	if value != 0 {
+		p.Values.Add(name, fmt.Sprint(value))
+	}
+}
+
+// MaybeAddBool adds the (name, value) pair iff value is true.
+func (p *URLParams) MaybeAddBool(name string, value bool) {
+	if value {
+		p.Values.Add(name, fmt.Sprint(value))
 	}
 }
 

--- a/urlparams.go
+++ b/urlparams.go
@@ -1,0 +1,31 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package gomaasapi
+
+import "net/url"
+
+// URLParams wraps url.Values to easily add values, but skipping empty ones.
+type URLParams struct {
+	Values url.Values
+}
+
+// NewURLParams allocates a new URLParams type.
+func NewURLParams() *URLParams {
+	return &URLParams{Values: make(url.Values)}
+}
+
+// MaybeAdd adds the (name, value) pair iff value is not empty.
+func (p *URLParams) MaybeAdd(name, value string) {
+	if value != "" {
+		p.Values.Add(name, value)
+	}
+}
+
+// MaybeAddMany adds the (name, value) for each value in values iff
+// value is not empty.
+func (p *URLParams) MaybeAddMany(name string, values []string) {
+	for _, value := range values {
+		p.MaybeAdd(name, value)
+	}
+}

--- a/urlparams_test.go
+++ b/urlparams_test.go
@@ -30,6 +30,30 @@ func (*urlParamsSuite) TestNewMaybeAddWithValue(c *gc.C) {
 	c.Assert(params.Values.Encode(), gc.Equals, "foo=bar")
 }
 
+func (*urlParamsSuite) TestNewMaybeAddIntZero(c *gc.C) {
+	params := gomaasapi.NewURLParams()
+	params.MaybeAddInt("foo", 0)
+	c.Assert(params.Values.Encode(), gc.Equals, "")
+}
+
+func (*urlParamsSuite) TestNewMaybeAddIntWithValue(c *gc.C) {
+	params := gomaasapi.NewURLParams()
+	params.MaybeAddInt("foo", 42)
+	c.Assert(params.Values.Encode(), gc.Equals, "foo=42")
+}
+
+func (*urlParamsSuite) TestNewMaybeAddBoolFalse(c *gc.C) {
+	params := gomaasapi.NewURLParams()
+	params.MaybeAddBool("foo", false)
+	c.Assert(params.Values.Encode(), gc.Equals, "")
+}
+
+func (*urlParamsSuite) TestNewMaybeAddBoolTrue(c *gc.C) {
+	params := gomaasapi.NewURLParams()
+	params.MaybeAddBool("foo", true)
+	c.Assert(params.Values.Encode(), gc.Equals, "foo=true")
+}
+
 func (*urlParamsSuite) TestNewMaybeAddManyNil(c *gc.C) {
 	params := gomaasapi.NewURLParams()
 	params.MaybeAddMany("foo", nil)

--- a/urlparams_test.go
+++ b/urlparams_test.go
@@ -1,0 +1,43 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package gomaasapi_test
+
+import (
+	"github.com/juju/gomaasapi"
+	gc "gopkg.in/check.v1"
+)
+
+type urlParamsSuite struct {
+}
+
+var _ = gc.Suite(&urlParamsSuite{})
+
+func (*urlParamsSuite) TestNewParamsNonNilValues(c *gc.C) {
+	params := gomaasapi.NewURLParams()
+	c.Assert(params.Values, gc.NotNil)
+}
+
+func (*urlParamsSuite) TestNewMaybeAddEmpty(c *gc.C) {
+	params := gomaasapi.NewURLParams()
+	params.MaybeAdd("foo", "")
+	c.Assert(params.Values.Encode(), gc.Equals, "")
+}
+
+func (*urlParamsSuite) TestNewMaybeAddWithValue(c *gc.C) {
+	params := gomaasapi.NewURLParams()
+	params.MaybeAdd("foo", "bar")
+	c.Assert(params.Values.Encode(), gc.Equals, "foo=bar")
+}
+
+func (*urlParamsSuite) TestNewMaybeAddManyNil(c *gc.C) {
+	params := gomaasapi.NewURLParams()
+	params.MaybeAddMany("foo", nil)
+	c.Assert(params.Values.Encode(), gc.Equals, "")
+}
+
+func (*urlParamsSuite) TestNewMaybeAddManyValues(c *gc.C) {
+	params := gomaasapi.NewURLParams()
+	params.MaybeAddMany("foo", []string{"two", "", "values"})
+	c.Assert(params.Values.Encode(), gc.Equals, "foo=two&foo=values")
+}


### PR DESCRIPTION
This branch adds the first of the POST methods, AllocateMachine. This meant there was a bit of churn around the testing http server to handle posts as well as gets, and to read the post form.

I also added a bunch of error types. I'd like all errors returned out of the new interfaces to be one of those errors. I have started by updating the machine and boot-resources parsing methods, but the others can be done as I touch the files again.

Added a helper method to get the ServerError, as it was being used in a bunch of tests.

Updated client_test.go to import gocheck with the "gc" name.

The post API call has been tested interactively with my test maas program. Yay dry run.

Go vet was complaining about Id saying it should be ID, and Cpu to be CPU, so I've updated those.

Also added a helper type to add url values only if they were non-zero.
