### PR TITLE
More networky fields

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -24,6 +24,9 @@ type interface_ struct {
 	macAddress   string
 	effectiveMTU int
 	params       string
+
+	parents  []string
+	children []string
 }
 
 // ID implements Interface.
@@ -34,6 +37,16 @@ func (i *interface_) ID() int {
 // Name implements Interface.
 func (i *interface_) Name() string {
 	return i.name
+}
+
+// Parents implements Interface.
+func (i *interface_) Parents() []string {
+	return i.parents
+}
+
+// Children implements Interface.
+func (i *interface_) Children() []string {
+	return i.children
 }
 
 // Type implements Interface.
@@ -155,6 +168,9 @@ func interface_2_0(source map[string]interface{}) (*interface_, error) {
 		"mac_address":   schema.String(),
 		"effective_mtu": schema.ForceInt(),
 		"params":        schema.String(),
+
+		"parents":  schema.List(schema.String()),
+		"children": schema.List(schema.String()),
 	}
 	checker := schema.FieldMap(fields, nil) // no defaults
 	coerced, err := checker.Coerce(source, nil)
@@ -188,6 +204,9 @@ func interface_2_0(source map[string]interface{}) (*interface_, error) {
 		macAddress:   valid["mac_address"].(string),
 		effectiveMTU: valid["effective_mtu"].(int),
 		params:       valid["params"].(string),
+
+		parents:  convertToStringSlice(valid["parents"]),
+		children: convertToStringSlice(valid["children"]),
 	}
 	return result, nil
 }

--- a/interface_test.go
+++ b/interface_test.go
@@ -40,6 +40,9 @@ func (s *interfaceSuite) checkInterface(c *gc.C, iface *interface_) {
 	c.Check(iface.EffectiveMTU(), gc.Equals, 1500)
 	c.Check(iface.Params(), gc.Equals, "some params")
 
+	c.Check(iface.Parents(), jc.DeepEquals, []string{"bond0"})
+	c.Check(iface.Children(), jc.DeepEquals, []string{"eth0.1", "eth0.2"})
+
 	vlan := iface.VLAN()
 	c.Assert(vlan, gc.NotNil)
 	c.Check(vlan.Name(), gc.Equals, "untagged")
@@ -86,7 +89,7 @@ const (
 {
     "effective_mtu": 1500,
     "mac_address": "52:54:00:c9:6a:45",
-    "children": [],
+    "children": ["eth0.1", "eth0.2"],
     "discovered": [],
     "params": "some params",
     "vlan": {
@@ -102,7 +105,7 @@ const (
     },
     "name": "eth0",
     "enabled": true,
-    "parents": [],
+    "parents": ["bond0"],
     "id": 40,
     "type": "physical",
     "resource_uri": "/MAAS/api/2.0/nodes/4y3ha6/interfaces/40/",

--- a/interfaces.go
+++ b/interfaces.go
@@ -212,7 +212,11 @@ type Subnet interface {
 
 	Gateway() string
 	CIDR() string
-	// DNS Servers, rdns_mode
+	// dns_mode
+
+	// DNSServers is a list of ip addresses of the DNS servers for the subnet.
+	// This list may be empty.
+	DNSServers() []string
 }
 
 // Interface represents a physical or virtual network interface on a Machine.

--- a/interfaces.go
+++ b/interfaces.go
@@ -223,6 +223,13 @@ type Subnet interface {
 type Interface interface {
 	ID() int
 	Name() string
+	// The parents of an interface are the names of interfaces that must exist
+	// for this interface  to exist. For example a parent of "eth0.100" would be
+	// "eth0". Parents may be empty.
+	Parents() []string
+	// The children interfaces are the names of those that are dependent on this
+	// interface existing. Children may be empty.
+	Children() []string
 	Type() string
 	Enabled() bool
 

--- a/subnet.go
+++ b/subnet.go
@@ -22,6 +22,8 @@ type subnet struct {
 
 	gateway string
 	cidr    string
+
+	dnsServers []string
 }
 
 // ID implements Subnet.
@@ -52,6 +54,11 @@ func (s *subnet) Gateway() string {
 // CIDR implements Subnet.
 func (s *subnet) CIDR() string {
 	return s.cidr
+}
+
+// DNSServers implements Subnet.
+func (s *subnet) DNSServers() []string {
+	return s.dnsServers
 }
 
 func readSubnets(controllerVersion version.Number, source interface{}) ([]*subnet, error) {
@@ -107,6 +114,7 @@ func subnet_2_0(source map[string]interface{}) (*subnet, error) {
 		"gateway_ip":   schema.OneOf(schema.Nil(""), schema.String()),
 		"cidr":         schema.String(),
 		"vlan":         schema.StringMap(schema.Any()),
+		"dns_servers":  schema.List(schema.String()),
 	}
 	checker := schema.FieldMap(fields, nil) // no defaults
 	coerced, err := checker.Coerce(source, nil)
@@ -135,6 +143,7 @@ func subnet_2_0(source map[string]interface{}) (*subnet, error) {
 		vlan:        vlan,
 		gateway:     gateway,
 		cidr:        valid["cidr"].(string),
+		dnsServers:  convertToStringSlice(valid["dns_servers"]),
 	}
 	return result, nil
 }

--- a/subnet_test.go
+++ b/subnet_test.go
@@ -32,6 +32,7 @@ func (*subnetSuite) TestReadSubnets(c *gc.C) {
 	vlan := subnet.VLAN()
 	c.Assert(vlan, gc.NotNil)
 	c.Assert(vlan.Name(), gc.Equals, "untagged")
+	c.Assert(subnet.DNSServers(), jc.DeepEquals, []string{"8.8.8.8", "8.8.4.4"})
 }
 
 func (*subnetSuite) TestLowVersion(c *gc.C) {
@@ -64,7 +65,7 @@ var subnetResponse = `
         "space": "space-0",
         "id": 1,
         "resource_uri": "/MAAS/api/2.0/subnets/1/",
-        "dns_servers": [],
+        "dns_servers": ["8.8.8.8", "8.8.4.4"],
         "cidr": "192.168.100.0/24",
         "rdns_mode": 2
     },


### PR DESCRIPTION
Expose Children and Parents of an Interface.
Expose the DNS Servers for a Subnet.
