### PR TITLE
Allocate machine with interface and storage constraints

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -282,9 +282,8 @@ func (c *controller) Machines(args MachinesArgs) ([]Machine, error) {
 // StorageSpec represents one element of storage constraints necessary
 // to be satisfied to allocate a machine.
 type StorageSpec struct {
-	// Label is optional and an arbitrary string.
-	// Labels need to be unique across the StorageSpec elements specified
-	// in the AllocateMachineArgs.
+	// Label is optional and an arbitrary string. Labels need to be unique
+	// across the StorageSpec elements specified in the AllocateMachineArgs.
 	Label string
 	// Size is required and refers to the required minimum size in GB.
 	Size int
@@ -322,7 +321,7 @@ func (s *StorageSpec) String() string {
 // InterfaceSpec represents one elemenet of network related constraints.
 type InterfaceSpec struct {
 	// Label is required and an arbitrary string. Labels need to be unique
-	// across the InterfaceSpec elements specified in the AllcoateMachineArgs.
+	// across the InterfaceSpec elements specified in the AllocateMachineArgs.
 	// The label is returned in the ConstraintMatches response from
 	// AllocateMachine.
 	Label    string

--- a/controller.go
+++ b/controller.go
@@ -284,7 +284,7 @@ func (c *controller) Machines(args MachinesArgs) ([]Machine, error) {
 type StorageSpec struct {
 	// Label is optional and an arbitrary string.
 	// Labels need to be unique across the StorageSpec elements specified
-	// in the AllcoateMachineArgs.
+	// in the AllocateMachineArgs.
 	Label string
 	// Size is required and refers to the required minimum size in GB.
 	Size int

--- a/controller.go
+++ b/controller.go
@@ -689,7 +689,7 @@ func parseAllocateConstraintsResponse(source interface{}, machine *machine) (Con
 	// TODO: handle storage when we export block devices.
 	if interfaceMatches, found := valid["interfaces"]; found {
 		for label, value := range interfaceMatches.(map[string]interface{}) {
-			id := int(value.(int64))
+			id := value.(int)
 			iface := machine.Interface(id)
 			if iface == nil {
 				return empty, NewDeserializationError("constraint match interface %q: %d does not match an interface for the machine", label, id)

--- a/errors.go
+++ b/errors.go
@@ -87,7 +87,14 @@ func WrapWithDeserializationError(err error, format string, args ...interface{})
 	// previous error, but wrap it in the new type.
 	derr := &DeserializationError{Err: errors.NewErr(message + ": " + err.Error())}
 	derr.SetLocation(1)
-	return errors.Wrap(err, derr)
+	wrapped := errors.Wrap(err, derr)
+	// We want the location of the wrapped error to be the caller of this function,
+	// not the line above.
+	if errType, ok := wrapped.(*errors.Err); ok {
+		// We know it is because that is what Wrap returns.
+		errType.SetLocation(1)
+	}
+	return wrapped
 }
 
 // IsDeserializationError returns true if err is a DeserializationError.

--- a/interfaces.go
+++ b/interfaces.go
@@ -40,7 +40,7 @@ type Controller interface {
 
 	// AllocateMachine will attempt to allocate a machine to the user.
 	// If successful, the allocated machine is returned.
-	AllocateMachine(AllocateMachineArgs) (Machine, error)
+	AllocateMachine(AllocateMachineArgs) (Machine, ConstraintMatches, error)
 
 	// ReleaseMachines will stop the specified machines, and release them
 	// from the user making them available to be allocated again.
@@ -191,6 +191,9 @@ type Machine interface {
 	BootInterface() Interface
 	// InterfaceSet returns all the interfaces for the Machine.
 	InterfaceSet() []Interface
+	// Interface returns the interface for the machine that matches the id
+	// specified. If there is no match, nil is returned.
+	Interface(id int) Interface
 
 	Zone() Zone
 

--- a/machine.go
+++ b/machine.go
@@ -116,6 +116,16 @@ func (m *machine) InterfaceSet() []Interface {
 	return result
 }
 
+// Interface implements Machine.
+func (m *machine) Interface(id int) Interface {
+	for _, iface := range m.interfaceSet {
+		if iface.ID() == id {
+			return iface
+		}
+	}
+	return nil
+}
+
 // OperatingSystem implements Machine.
 func (m *machine) OperatingSystem() string {
 	return m.operatingSystem

--- a/machine_test.go
+++ b/machine_test.go
@@ -62,6 +62,9 @@ func (*machineSuite) TestReadMachines(c *gc.C) {
 
 	interfaceSet := machine.InterfaceSet()
 	c.Assert(interfaceSet, gc.HasLen, 1)
+	id := interfaceSet[0].ID()
+	c.Assert(machine.Interface(id), jc.DeepEquals, interfaceSet[0])
+	c.Assert(machine.Interface(id+5), gc.IsNil)
 }
 
 func (*machineSuite) TestLowVersion(c *gc.C) {


### PR DESCRIPTION
After talking with the MaaS folks, I got a better understanding of the allocation process.

In particular the mapping of storage devices and interfaces to the constraints requested.
There is a dictionary in the response structure of allocate that isn't a standard machine attribute that indicates how the machine was chosen. The keys in this dictionary are only specified when constraints of that type are specified.
