### PR TITLE
Expose the interfaces of a device.

### DIFF
--- a/device.go
+++ b/device.go
@@ -51,6 +51,27 @@ func (d *device) Zone() Zone {
 	return d.zone
 }
 
+// InterfaceSet implements Device.
+func (d *device) InterfaceSet() ([]Interface, error) {
+	// NOTE: the get and extra parse will not be necessary
+	// when r4900 of maas has been packaged and released.
+	source, err := d.controller.get(d.interfacesURI())
+	if err != nil {
+		return nil, NewUnexpectedError(err)
+	}
+	ifaces, err := readInterfaces(d.controller.apiVersion, source)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	result := make([]Interface, len(ifaces))
+	for i, v := range ifaces {
+		v.controller = d.controller
+		result[i] = v
+	}
+	return result, nil
+}
+
 // CreateInterfaceArgs is an argument struct for passing parameters to
 // the Machine.CreateInterface method.
 type CreateInterfaceArgs struct {

--- a/device_test.go
+++ b/device_test.go
@@ -51,6 +51,15 @@ func (*deviceSuite) TestHighVersion(c *gc.C) {
 	c.Assert(devices, gc.HasLen, 1)
 }
 
+func (s *deviceSuite) TestInterfaceSet(c *gc.C) {
+	server, device := s.getServerAndDevice(c)
+	server.AddGetResponse(device.interfacesURI(), http.StatusOK, interfacesResponse)
+
+	ifaces, err := device.InterfaceSet()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ifaces, gc.HasLen, 1)
+}
+
 type fakeVLAN struct {
 	VLAN
 	id int

--- a/interfaces.go
+++ b/interfaces.go
@@ -160,6 +160,12 @@ type Device interface {
 
 	// Parent, Owner, MAC Addresses if needed
 
+	// InterfaceSet returns all the interfaces for the Device. This is an
+	// interim call until r4900 is packaged, when we will be able to remove the
+	// error response as the device JSON will include the interface set which
+	// will be able to be parsed at object creation time.
+	InterfaceSet() ([]Interface, error)
+
 	// CreateInterface will create a physical interface for this machine.
 	CreateInterface(CreateInterfaceArgs) (Interface, error)
 


### PR DESCRIPTION
There is work committed to maas master that adds interface_set to the devices response, but it isn't there yet.
