### PR TITLE
Devices for a Machine.

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -191,6 +191,10 @@ type Machine interface {
 	IPAddresses() []string
 	PowerState() string
 
+	// Devices returns a list of devices that match the params and have
+	// this Machine as the parent.
+	Devices(DevicesArgs) ([]Device, error)
+
 	// Consider bundling the status values into a single struct.
 	// but need to check for consistent representation if exposed on other
 	// entities.

--- a/machine.go
+++ b/machine.go
@@ -154,6 +154,23 @@ func (m *machine) StatusMessage() string {
 	return m.statusMessage
 }
 
+// Devices implements Machine.
+func (m *machine) Devices(args DevicesArgs) ([]Device, error) {
+	// Perhaps in the future, MAAS will give us a way to query just for the
+	// devices for a particular parent.
+	devices, err := m.controller.Devices(args)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	var result []Device
+	for _, device := range devices {
+		if device.Parent() == m.SystemID() {
+			result = append(result, device)
+		}
+	}
+	return result, nil
+}
+
 // StartArgs is an argument struct for passing parameters to the Machine.Start
 // method.
 type StartArgs struct {

--- a/machine_test.go
+++ b/machine_test.go
@@ -158,6 +158,26 @@ func (s *machineSuite) TestStartMachineUnknown(c *gc.C) {
 	c.Assert(err.Error(), gc.Equals, "unexpected: ServerError: 405 Method Not Allowed (wat?)")
 }
 
+func (s *machineSuite) TestDevices(c *gc.C) {
+	server, machine := s.getServerAndMachine(c)
+	server.AddGetResponse("/api/2.0/devices/", http.StatusOK, devicesResponse)
+	devices, err := machine.Devices(DevicesArgs{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(devices, gc.HasLen, 1)
+	c.Assert(devices[0].Parent(), gc.Equals, machine.SystemID())
+}
+
+func (s *machineSuite) TestDevicesNone(c *gc.C) {
+	server, machine := s.getServerAndMachine(c)
+	response := updateJSONMap(c, deviceResponse, map[string]interface{}{
+		"parent": "other",
+	})
+	server.AddGetResponse("/api/2.0/devices/", http.StatusOK, "["+response+"]")
+	devices, err := machine.Devices(DevicesArgs{})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(devices, gc.HasLen, 0)
+}
+
 const (
 	machineResponse = `
 	{


### PR DESCRIPTION
For now, just gets all the devices and filters based on the machine system ID.

Added a feature request for MAAS to be able to support querying devices for a particular parent.
