### PR TITLE
Remove create op name.

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -224,7 +224,7 @@ func (c *controller) CreateDevice(args CreateDeviceArgs) (Device, error) {
 	params.MaybeAdd("domain", args.Domain)
 	params.MaybeAddMany("mac_addresses", args.MACAddresses)
 	params.MaybeAdd("parent", args.Parent)
-	result, err := c.post("devices", "create", params.Values)
+	result, err := c.post("devices", "", params.Values)
 	if err != nil {
 		if svrErr, ok := errors.Cause(err).(ServerError); ok {
 			if svrErr.StatusCode == http.StatusBadRequest {
@@ -625,7 +625,7 @@ func (c *controller) AddFile(args AddFileArgs) error {
 		fileContent = content
 	}
 	params := url.Values{"filename": {args.Filename}}
-	_, err := c.postFile("files", "create", params, fileContent)
+	_, err := c.postFile("files", "", params, fileContent)
 	if err != nil {
 		if svrErr, ok := errors.Cause(err).(ServerError); ok {
 			if svrErr.StatusCode == http.StatusBadRequest {
@@ -692,7 +692,13 @@ func (c *controller) postFile(path, op string, params url.Values, fileContent []
 func (c *controller) _postRaw(path, op string, params url.Values, files map[string][]byte) ([]byte, error) {
 	path = EnsureTrailingSlash(path)
 	requestID := nextRequestID()
-	logger.Tracef("request %x: POST %s%s?op=%s, params=%s", requestID, c.client.APIURL, path, op, params.Encode())
+	if logger.IsTraceEnabled() {
+		opArg := ""
+		if op != "" {
+			opArg = "?op=" + op
+		}
+		logger.Tracef("request %x: POST %s%s%s, params=%s", requestID, c.client.APIURL, path, opArg, params.Encode())
+	}
 	bytes, err := c.client.Post(&url.URL{Path: path}, op, params, files)
 	if err != nil {
 		logger.Tracef("response %x: error: %q", requestID, err.Error())

--- a/controller_test.go
+++ b/controller_test.go
@@ -164,7 +164,7 @@ func (s *controllerSuite) TestDevicesArgs(c *gc.C) {
 }
 
 func (s *controllerSuite) TestCreateDevice(c *gc.C) {
-	s.server.AddPostResponse("/api/2.0/devices/?op=create", http.StatusOK, deviceResponse)
+	s.server.AddPostResponse("/api/2.0/devices/?op=", http.StatusOK, deviceResponse)
 	controller := s.getController(c)
 	device, err := controller.CreateDevice(CreateDeviceArgs{
 		MACAddresses: []string{"a-mac-address"},
@@ -181,7 +181,7 @@ func (s *controllerSuite) TestCreateDeviceMissingAddress(c *gc.C) {
 }
 
 func (s *controllerSuite) TestCreateDeviceBadRequest(c *gc.C) {
-	s.server.AddPostResponse("/api/2.0/devices/?op=create", http.StatusBadRequest, "some error")
+	s.server.AddPostResponse("/api/2.0/devices/?op=", http.StatusBadRequest, "some error")
 	controller := s.getController(c)
 	_, err := controller.CreateDevice(CreateDeviceArgs{
 		MACAddresses: []string{"a-mac-address"},
@@ -191,7 +191,7 @@ func (s *controllerSuite) TestCreateDeviceBadRequest(c *gc.C) {
 }
 
 func (s *controllerSuite) TestCreateDeviceArgs(c *gc.C) {
-	s.server.AddPostResponse("/api/2.0/devices/?op=create", http.StatusOK, deviceResponse)
+	s.server.AddPostResponse("/api/2.0/devices/?op=", http.StatusOK, deviceResponse)
 	controller := s.getController(c)
 	// Create an arg structure that sets all the values.
 	args := CreateDeviceArgs{
@@ -669,7 +669,7 @@ func (s *controllerSuite) assertFile(c *gc.C, request *http.Request, filename, c
 }
 
 func (s *controllerSuite) TestAddFileContent(c *gc.C) {
-	s.server.AddPostResponse("/api/2.0/files/?op=create", http.StatusOK, "")
+	s.server.AddPostResponse("/api/2.0/files/?op=", http.StatusOK, "")
 	controller := s.getController(c)
 	err := controller.AddFile(AddFileArgs{
 		Filename: "foo.txt",
@@ -683,7 +683,7 @@ func (s *controllerSuite) TestAddFileContent(c *gc.C) {
 
 func (s *controllerSuite) TestAddFileReader(c *gc.C) {
 	reader := bytes.NewBufferString("test\n extra over length ignored")
-	s.server.AddPostResponse("/api/2.0/files/?op=create", http.StatusOK, "")
+	s.server.AddPostResponse("/api/2.0/files/?op=", http.StatusOK, "")
 	controller := s.getController(c)
 	err := controller.AddFile(AddFileArgs{
 		Filename: "foo.txt",


### PR DESCRIPTION
As per comment in lp bug 1569678, the "create" op was working by accident and wasn't intentional.

Removed the use of this in the library. Unfortunately, the url that is generated always sets "op" even when empty so the urls finish with "?op=", which is a bit fugly, but ok in tests, and maas doesn't care.
