### PR TITLE
Create device for machine

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -224,7 +224,7 @@ func (c *controller) CreateDevice(args CreateDeviceArgs) (Device, error) {
 	params.MaybeAdd("domain", args.Domain)
 	params.MaybeAddMany("mac_addresses", args.MACAddresses)
 	params.MaybeAdd("parent", args.Parent)
-	result, err := c.post("devices", "create", params.Values)
+	result, err := c.post("devices", "", params.Values)
 	if err != nil {
 		if svrErr, ok := errors.Cause(err).(ServerError); ok {
 			if svrErr.StatusCode == http.StatusBadRequest {

--- a/interfaces.go
+++ b/interfaces.go
@@ -210,6 +210,10 @@ type Machine interface {
 
 	// Start the machine and install the operating system specified in the args.
 	Start(StartArgs) error
+
+	// CreateDevice creates a new Device with this Machine as the parent.
+	// The device will have one interface that is linked to the specified subnet.
+	CreateDevice(CreateMachineDeviceArgs) (Device, error)
 }
 
 // Space is a name for a collection of Subnets.

--- a/machine.go
+++ b/machine.go
@@ -239,6 +239,9 @@ func (a *CreateMachineDeviceArgs) Validate() error {
 
 // CreateDevice implements Machine
 func (m *machine) CreateDevice(args CreateMachineDeviceArgs) (_ Device, err error) {
+	if err := args.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
 	device, err := m.controller.CreateDevice(CreateDeviceArgs{
 		Hostname:     args.Hostname,
 		MACAddresses: []string{args.MACAddress},

--- a/machine.go
+++ b/machine.go
@@ -197,6 +197,85 @@ func (m *machine) Start(args StartArgs) error {
 	return nil
 }
 
+// CreateMachineDeviceArgs is an argument structure for Machine.CreateDevice.
+// All fields are required.
+type CreateMachineDeviceArgs struct {
+	Hostname      string
+	InterfaceName string
+	MACAddress    string
+	Subnet        Subnet
+}
+
+// Validate ensures that all values are non-emtpy.
+func (a *CreateMachineDeviceArgs) Validate() error {
+	if a.Hostname == "" {
+		return errors.NotValidf("missing Hostname")
+	}
+	if a.InterfaceName == "" {
+		return errors.NotValidf("missing InterfaceName")
+	}
+	if a.MACAddress == "" {
+		return errors.NotValidf("missing MACAddress")
+	}
+	if a.Subnet == nil {
+		return errors.NotValidf("missing Subnet")
+	}
+	return nil
+}
+
+// CreateDevice implements Machine
+func (m *machine) CreateDevice(args CreateMachineDeviceArgs) (_ Device, err error) {
+	device, err := m.controller.CreateDevice(CreateDeviceArgs{
+		Hostname:     args.Hostname,
+		MACAddresses: []string{args.MACAddress},
+		Parent:       m.SystemID(),
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	defer func() {
+		// If there is an error return, at least try to delete the device we just created.
+		if err != nil {
+			if innerErr := device.Delete(); innerErr != nil {
+				logger.Warningf("could not delete device %q", device.SystemID())
+			}
+		}
+	}()
+
+	// There should be one interface created for each MAC Address, and since
+	// we only specified one, there should just be one response.
+	interfaces := device.InterfaceSet()
+	if count := len(interfaces); count != 1 {
+		err := errors.Errorf("unexpected interface count for device: %d", count)
+		return nil, NewUnexpectedError(err)
+	}
+	iface := interfaces[0]
+
+	// Now update the name and vlan of interface that was created…
+	updateArgs := UpdateInterfaceArgs{}
+	if iface.Name() != args.InterfaceName {
+		updateArgs.Name = args.InterfaceName
+	}
+	if iface.VLAN().ID() != args.Subnet.VLAN().ID() {
+		updateArgs.VLAN = iface.VLAN()
+	}
+	err = iface.Update(updateArgs)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	err = iface.LinkSubnet(LinkSubnetArgs{
+		Mode:   LinkModeStatic,
+		Subnet: args.Subnet,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return device, nil
+}
+
 func readMachine(controllerVersion version.Number, source interface{}) (*machine, error) {
 	readFunc, err := getMachineDeserializationFunc(controllerVersion)
 	if err != nil {

--- a/machine.go
+++ b/machine.go
@@ -215,7 +215,7 @@ func (m *machine) Start(args StartArgs) error {
 }
 
 // CreateMachineDeviceArgs is an argument structure for Machine.CreateDevice.
-// All fields are required.
+// All fields except Hostname are required.
 type CreateMachineDeviceArgs struct {
 	Hostname      string
 	InterfaceName string
@@ -223,11 +223,8 @@ type CreateMachineDeviceArgs struct {
 	Subnet        Subnet
 }
 
-// Validate ensures that all values are non-emtpy.
+// Validate ensures that all required values are non-emtpy.
 func (a *CreateMachineDeviceArgs) Validate() error {
-	if a.Hostname == "" {
-		return errors.NotValidf("missing Hostname")
-	}
 	if a.InterfaceName == "" {
 		return errors.NotValidf("missing InterfaceName")
 	}


### PR DESCRIPTION
One method to create the device with the machine set as the parent, update the interface to match the interface name and vlan of the subnet, then link the interface to the subnet.

All things that we need to do for each container Juju tries to use on a machine.
