### PR TITLE
VLAN name is optional in 2.0 API schema

### DIFF
--- a/vlan.go
+++ b/vlan.go
@@ -114,7 +114,7 @@ func vlan_2_0(source map[string]interface{}) (*vlan, error) {
 	fields := schema.Fields{
 		"id":           schema.ForceInt(),
 		"resource_uri": schema.String(),
-		"name":         schema.String(),
+		"name":         schema.OneOf(schema.Nil(""), schema.String()),
 		"fabric":       schema.String(),
 		"vid":          schema.ForceInt(),
 		"mtu":          schema.ForceInt(),
@@ -137,11 +137,12 @@ func vlan_2_0(source map[string]interface{}) (*vlan, error) {
 	// we care about, which is the empty string.
 	primary_rack, _ := valid["primary_rack"].(string)
 	secondary_rack, _ := valid["secondary_rack"].(string)
+	name, _ := valid["name"].(string)
 
 	result := &vlan{
 		resourceURI:   valid["resource_uri"].(string),
 		id:            valid["id"].(int),
-		name:          valid["name"].(string),
+		name:          name,
 		fabric:        valid["fabric"].(string),
 		vid:           valid["vid"].(int),
 		mtu:           valid["mtu"].(int),

--- a/vlan_test.go
+++ b/vlan_test.go
@@ -13,38 +13,69 @@ type vlanSuite struct{}
 
 var _ = gc.Suite(&vlanSuite{})
 
-func (*vlanSuite) TestreadVLANsBadSchema(c *gc.C) {
+func (*vlanSuite) TestReadVLANsBadSchema(c *gc.C) {
 	_, err := readVLANs(twoDotOh, "wat?")
 	c.Assert(err.Error(), gc.Equals, `vlan base schema check failed: expected list, got string("wat?")`)
 }
 
-func (*vlanSuite) TestreadVLANs(c *gc.C) {
-	vlans, err := readVLANs(twoDotOh, parseJSON(c, vlanResponse))
+func (s *vlanSuite) TestReadVLANsWithName(c *gc.C) {
+	vlans, err := readVLANs(twoDotOh, parseJSON(c, vlanResponseWithName))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(vlans, gc.HasLen, 1)
-	vlan := vlans[0]
-	c.Assert(vlan.ID(), gc.Equals, 1)
-	c.Assert(vlan.Name(), gc.Equals, "untagged")
-	c.Assert(vlan.Fabric(), gc.Equals, "fabric-0")
-	c.Assert(vlan.VID(), gc.Equals, 2)
-	c.Assert(vlan.MTU(), gc.Equals, 1500)
-	c.Assert(vlan.DHCP(), jc.IsTrue)
-	c.Assert(vlan.PrimaryRack(), gc.Equals, "a-rack")
-	c.Assert(vlan.SecondaryRack(), gc.Equals, "")
+	readVLAN := vlans[0]
+	s.assertVLAN(c, readVLAN, &vlan{
+		id:            1,
+		name:          "untagged",
+		fabric:        "fabric-0",
+		vid:           2,
+		mtu:           1500,
+		dhcp:          true,
+		primaryRack:   "a-rack",
+		secondaryRack: "",
+	})
+}
+
+func (*vlanSuite) assertVLAN(c *gc.C, givenVLAN, expectedVLAN *vlan) {
+	c.Check(givenVLAN.ID(), gc.Equals, expectedVLAN.id)
+	c.Check(givenVLAN.Name(), gc.Equals, expectedVLAN.name)
+	c.Check(givenVLAN.Fabric(), gc.Equals, expectedVLAN.fabric)
+	c.Check(givenVLAN.VID(), gc.Equals, expectedVLAN.vid)
+	c.Check(givenVLAN.MTU(), gc.Equals, expectedVLAN.mtu)
+	c.Check(givenVLAN.DHCP(), gc.Equals, expectedVLAN.dhcp)
+	c.Check(givenVLAN.PrimaryRack(), gc.Equals, expectedVLAN.primaryRack)
+	c.Check(givenVLAN.SecondaryRack(), gc.Equals, expectedVLAN.secondaryRack)
+}
+
+func (s *vlanSuite) TestReadVLANsWithoutName(c *gc.C) {
+	vlans, err := readVLANs(twoDotOh, parseJSON(c, vlanResponseWithoutName))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(vlans, gc.HasLen, 1)
+	readVLAN := vlans[0]
+	s.assertVLAN(c, readVLAN, &vlan{
+		id:            5006,
+		name:          "",
+		fabric:        "maas-management",
+		vid:           30,
+		mtu:           1500,
+		dhcp:          true,
+		primaryRack:   "4y3h7n",
+		secondaryRack: "",
+	})
 }
 
 func (*vlanSuite) TestLowVersion(c *gc.C) {
-	_, err := readVLANs(version.MustParse("1.9.0"), parseJSON(c, vlanResponse))
+	_, err := readVLANs(version.MustParse("1.9.0"), parseJSON(c, vlanResponseWithName))
 	c.Assert(err.Error(), gc.Equals, `no vlan read func for version 1.9.0`)
 }
 
 func (*vlanSuite) TestHighVersion(c *gc.C) {
-	vlans, err := readVLANs(version.MustParse("2.1.9"), parseJSON(c, vlanResponse))
+	vlans, err := readVLANs(version.MustParse("2.1.9"), parseJSON(c, vlanResponseWithoutName))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(vlans, gc.HasLen, 1)
 }
 
-var vlanResponse = `
+const (
+	vlanResponseWithName = `
 [
     {
         "name": "untagged",
@@ -59,3 +90,20 @@ var vlanResponse = `
     }
 ]
 `
+	vlanResponseWithoutName = `
+[
+    {
+        "dhcp_on": true,
+        "id": 5006,
+        "mtu": 1500,
+        "fabric": "maas-management",
+        "vid": 30,
+        "primary_rack": "4y3h7n",
+        "name": null,
+        "external_dhcp": null,
+        "resource_uri": "/MAAS/api/2.0/vlans/5006/",
+        "secondary_rack": null
+    }
+]
+`
+)


### PR DESCRIPTION
Discovered while trying to bootstrap with Juju on MAAS 2.0.
With this fix the bootstrap ~~almost completes, but at least goes further.~~ completes OK,
after increasing the `bootstrap-timeout` to 1200 (from the default 600)! Hardware NUCs
seem to need a bit more time than KVM nodes.
