### PR TITLE
Make dns_servers optional in subnets

### DIFF
--- a/subnet.go
+++ b/subnet.go
@@ -114,7 +114,7 @@ func subnet_2_0(source map[string]interface{}) (*subnet, error) {
 		"gateway_ip":   schema.OneOf(schema.Nil(""), schema.String()),
 		"cidr":         schema.String(),
 		"vlan":         schema.StringMap(schema.Any()),
-		"dns_servers":  schema.List(schema.String()),
+		"dns_servers":  schema.OneOf(schema.Nil(""), schema.List(schema.String())),
 	}
 	checker := schema.FieldMap(fields, nil) // no defaults
 	coerced, err := checker.Coerce(source, nil)

--- a/subnet_test.go
+++ b/subnet_test.go
@@ -86,7 +86,6 @@ var subnetResponse = `
         "space": "space-0",
         "id": 34,
         "resource_uri": "/MAAS/api/2.0/subnets/34/",
-        "dns_servers": [],
         "cidr": "192.168.122.0/24",
         "rdns_mode": 2
     }

--- a/subnet_test.go
+++ b/subnet_test.go
@@ -86,6 +86,7 @@ var subnetResponse = `
         "space": "space-0",
         "id": 34,
         "resource_uri": "/MAAS/api/2.0/subnets/34/",
+        "dns_servers": null,
         "cidr": "192.168.122.0/24",
         "rdns_mode": 2
     }


### PR DESCRIPTION
Make dns_servers optional in the subnets response from MAAS 2.
