### PR TITLE
Make interface_set optional in device_2_0

### DIFF
--- a/device.go
+++ b/device.go
@@ -247,7 +247,7 @@ func device_2_0(source map[string]interface{}) (*device, error) {
 		"owner":     schema.String(),
 
 		"ip_addresses":  schema.List(schema.String()),
-		"interface_set": schema.List(schema.StringMap(schema.Any())),
+		"interface_set": schema.OneOf(schema.Nil(""), schema.List(schema.StringMap(schema.Any()))),
 		"zone":          schema.StringMap(schema.Any()),
 	}
 	checker := schema.FieldMap(fields, nil) // no defaults
@@ -259,9 +259,12 @@ func device_2_0(source map[string]interface{}) (*device, error) {
 	// From here we know that the map returned from the schema coercion
 	// contains fields of the right type.
 
-	interfaceSet, err := readInterfaceList(valid["interface_set"].([]interface{}), interface_2_0)
-	if err != nil {
-		return nil, errors.Trace(err)
+	var interfaceSet []*interface_
+	if valid["interface_set"] != nil {
+		interfaceSet, err = readInterfaceList(valid["interface_set"].([]interface{}), interface_2_0)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 	zone, err := zone_2_0(valid["zone"].(map[string]interface{}))
 	if err != nil {

--- a/device_test.go
+++ b/device_test.go
@@ -35,6 +35,23 @@ func (*deviceSuite) TestReadDevices(c *gc.C) {
 	c.Check(device.Hostname(), gc.Equals, "furnacelike-brittney")
 	c.Check(device.FQDN(), gc.Equals, "furnacelike-brittney.maas")
 	c.Check(device.IPAddresses(), jc.DeepEquals, []string{"192.168.100.11"})
+	c.Check(device.InterfaceSet(), gc.HasLen, 2)
+	zone := device.Zone()
+	c.Check(zone, gc.NotNil)
+	c.Check(zone.Name(), gc.Equals, "default")
+}
+
+func (*deviceSuite) TestReadDevicesNoInterfaceSet(c *gc.C) {
+	devices, err := readDevices(twoDotOh, parseJSON(c, noInterfacesDevicesResponse))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(devices, gc.HasLen, 1)
+
+	device := devices[0]
+	c.Check(device.SystemID(), gc.Equals, "4y3h7t")
+	c.Check(device.Hostname(), gc.Equals, "pericarpic-leslee")
+	c.Check(device.FQDN(), gc.Equals, "pericarpic-leslee.maas")
+	c.Check(device.IPAddresses(), gc.DeepEquals, []string{})
+	c.Check(device.InterfaceSet(), gc.DeepEquals, []Interface{})
 	zone := device.Zone()
 	c.Check(zone, gc.NotNil)
 	c.Check(zone.Name(), gc.Equals, "default")
@@ -298,4 +315,37 @@ const (
     }
     `
 	devicesResponse = "[" + deviceResponse + "]"
+
+	noInterfacesDevicesResponse = `
+    [{
+        "node_type": 1,
+        "node_type_name": "Device",
+        "zone": {
+            "resource_uri": "/MAAS/api/2.0/zones/default/",
+            "name": "default",
+            "description": ""
+        },
+        "fqdn": "pericarpic-leslee.maas",
+        "hostname": "pericarpic-leslee",
+        "ip_addresses": [],
+        "macaddress_set": [
+            {
+                "mac_address": "00:16:3e:ab:0f:54"
+            }
+        ],
+        "tag_names": [],
+        "domain": {
+            "resource_record_count": 2,
+            "ttl": null,
+            "id": 0,
+            "authoritative": true,
+            "resource_uri": "/MAAS/api/2.0/domains/0/",
+            "name": "maas"
+        },
+        "owner": "admin",
+        "resource_uri": "/MAAS/api/2.0/devices/4y3h7t/",
+        "system_id": "4y3h7t",
+        "parent": "4y3h7p"
+    }]
+    `
 )


### PR DESCRIPTION
Devices with no interface_set attributes have been observed in testing with KVM-based MAAS 2 clusters.
