### PR TITLE
Don't return typed nil interface values

### DIFF
--- a/device.go
+++ b/device.go
@@ -62,6 +62,9 @@ func (d *device) IPAddresses() []string {
 
 // Zone implements Device.
 func (d *device) Zone() Zone {
+	if d.zone == nil {
+		return nil
+	}
 	return d.zone
 }
 

--- a/device_test.go
+++ b/device_test.go
@@ -19,6 +19,11 @@ type deviceSuite struct {
 
 var _ = gc.Suite(&deviceSuite{})
 
+func (*deviceSuite) TestNilZone(c *gc.C) {
+	var empty device
+	c.Check(empty.Zone() == nil, jc.IsTrue)
+}
+
 func (*deviceSuite) TestReadDevicesBadSchema(c *gc.C) {
 	_, err := readDevices(twoDotOh, "wat?")
 	c.Check(err, jc.Satisfies, IsDeserializationError)

--- a/interface.go
+++ b/interface.go
@@ -86,6 +86,9 @@ func (i *interface_) Tags() []string {
 
 // VLAN implements Interface.
 func (i *interface_) VLAN() VLAN {
+	if i.vlan == nil {
+		return nil
+	}
 	return i.vlan
 }
 

--- a/interface_test.go
+++ b/interface_test.go
@@ -19,6 +19,11 @@ type interfaceSuite struct {
 
 var _ = gc.Suite(&interfaceSuite{})
 
+func (*interfaceSuite) TestNilVLAN(c *gc.C) {
+	var empty interface_
+	c.Check(empty.VLAN() == nil, jc.IsTrue)
+}
+
 func (*interfaceSuite) TestReadInterfacesBadSchema(c *gc.C) {
 	_, err := readInterfaces(twoDotOh, "wat?")
 	c.Check(err, jc.Satisfies, IsDeserializationError)

--- a/link.go
+++ b/link.go
@@ -31,6 +31,9 @@ func (k *link) Mode() string {
 
 // Subnet implements Link.
 func (k *link) Subnet() Subnet {
+	if k.subnet == nil {
+		return nil
+	}
 	return k.subnet
 }
 

--- a/link_test.go
+++ b/link_test.go
@@ -13,6 +13,11 @@ type linkSuite struct{}
 
 var _ = gc.Suite(&linkSuite{})
 
+func (*linkSuite) TestNilSubnet(c *gc.C) {
+	var empty link
+	c.Check(empty.Subnet() == nil, jc.IsTrue)
+}
+
 func (*linkSuite) TestReadLinksBadSchema(c *gc.C) {
 	_, err := readLinks(twoDotOh, "wat?")
 	c.Check(err, jc.Satisfies, IsDeserializationError)

--- a/machine.go
+++ b/machine.go
@@ -101,11 +101,17 @@ func (m *machine) PowerState() string {
 
 // Zone implements Machine.
 func (m *machine) Zone() Zone {
+	if m.zone == nil {
+		return nil
+	}
 	return m.zone
 }
 
 // BootInterface implements Machine.
 func (m *machine) BootInterface() Interface {
+	if m.bootInterface == nil {
+		return nil
+	}
 	m.bootInterface.controller = m.controller
 	return m.bootInterface
 }

--- a/machine_test.go
+++ b/machine_test.go
@@ -19,6 +19,14 @@ type machineSuite struct {
 
 var _ = gc.Suite(&machineSuite{})
 
+func (*machineSuite) TestNilGetters(c *gc.C) {
+	var empty machine
+	c.Check(empty.Zone() == nil, jc.IsTrue)
+	c.Check(empty.PhysicalBlockDevice(0) == nil, jc.IsTrue)
+	c.Check(empty.Interface(0) == nil, jc.IsTrue)
+	c.Check(empty.BootInterface() == nil, jc.IsTrue)
+}
+
 func (*machineSuite) TestReadMachinesBadSchema(c *gc.C) {
 	_, err := readMachines(twoDotOh, "wat?")
 	c.Check(err, jc.Satisfies, IsDeserializationError)

--- a/partition.go
+++ b/partition.go
@@ -34,6 +34,9 @@ func (p *partition) Path() string {
 
 // FileSystem implements Partition.
 func (p *partition) FileSystem() FileSystem {
+	if p.filesystem == nil {
+		return nil
+	}
 	return p.filesystem
 }
 

--- a/partition_test.go
+++ b/partition_test.go
@@ -13,6 +13,11 @@ type partitionSuite struct{}
 
 var _ = gc.Suite(&partitionSuite{})
 
+func (*partitionSuite) TestNilFileSystem(c *gc.C) {
+	var empty partition
+	c.Assert(empty.FileSystem() == nil, jc.IsTrue)
+}
+
 func (*partitionSuite) TestReadPartitionsBadSchema(c *gc.C) {
 	_, err := readPartitions(twoDotOh, "wat?")
 	c.Check(err, jc.Satisfies, IsDeserializationError)

--- a/subnet.go
+++ b/subnet.go
@@ -43,6 +43,9 @@ func (s *subnet) Space() string {
 
 // VLAN implements Subnet.
 func (s *subnet) VLAN() VLAN {
+	if s.vlan == nil {
+		return nil
+	}
 	return s.vlan
 }
 

--- a/subnet_test.go
+++ b/subnet_test.go
@@ -13,6 +13,11 @@ type subnetSuite struct{}
 
 var _ = gc.Suite(&subnetSuite{})
 
+func (*subnetSuite) TestNilVLAN(c *gc.C) {
+	var empty subnet
+	c.Check(empty.VLAN() == nil, jc.IsTrue)
+}
+
 func (*subnetSuite) TestReadSubnetsBadSchema(c *gc.C) {
 	_, err := readSubnets(twoDotOh, "wat?")
 	c.Assert(err.Error(), gc.Equals, `subnet base schema check failed: expected list, got string("wat?")`)


### PR DESCRIPTION
Fix crash in Juju caused by typed nil Link.
https://bugs.launchpad.net/juju-core/+bug/1573659
The line immediately before the panic checked for nil, but because the type pointer is set on the Link it wasn't equal to nil.

From reading about this it seems like methods that return interfaces shouldn't implicitly return nil values, they should return nil explicitly, otherwise the result will be a typed nil. Checking for a typed nil on the client side is awkward - if the underlying type is known and accessible you could try a type assertion, otherwise it requires reflection.

https://golang.org/doc/faq#nil_error
(About errors, but applies to any interface.)
