### PR TITLE
Use the correct VLAN in machine.CreateDevice

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -308,7 +308,7 @@ func (m *machine) CreateDevice(args CreateMachineDeviceArgs) (_ Device, err erro
 		updateArgs.Name = args.InterfaceName
 	}
 	if iface.VLAN().ID() != args.Subnet.VLAN().ID() {
-		updateArgs.VLAN = iface.VLAN()
+		updateArgs.VLAN = args.Subnet.VLAN()
 	}
 	err = iface.Update(updateArgs)
 	if err != nil {

--- a/machine_test.go
+++ b/machine_test.go
@@ -270,6 +270,7 @@ func (s *machineSuite) TestCreateDevice(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(device.InterfaceSet()[0].Name(), gc.Equals, "eth4")
+	c.Assert(device.InterfaceSet()[0].VLAN().ID(), gc.Equals, subnet.VLAN().ID())
 }
 
 func (s *machineSuite) TestCreateDeviceTriesToDeleteDeviceOnError(c *gc.C) {


### PR DESCRIPTION
machine.CreateDevice was using the wrong VLAN in the update call.
