### PR TITLE
Boot resource kflavor is optional

### DIFF
--- a/bootresource.go
+++ b/bootresource.go
@@ -108,7 +108,7 @@ func bootResource_2_0(source map[string]interface{}) (*bootResource, error) {
 		"type":         schema.String(),
 		"architecture": schema.String(),
 		"subarches":    schema.String(),
-		"kflavor":      schema.String(),
+		"kflavor":      schema.OneOf(schema.Nil(""), schema.String()),
 	}
 	checker := schema.FieldMap(fields, nil) // no defaults
 	coerced, err := checker.Coerce(source, nil)
@@ -118,6 +118,10 @@ func bootResource_2_0(source map[string]interface{}) (*bootResource, error) {
 	valid := coerced.(map[string]interface{})
 	// From here we know that the map returned from the schema coercion
 	// contains fields of the right type.
+	var kflavor string
+	if valid["kflavor"] != nil {
+		kflavor = valid["kflavor"].(string)
+	}
 
 	result := &bootResource{
 		resourceURI:  valid["resource_uri"].(string),
@@ -126,7 +130,7 @@ func bootResource_2_0(source map[string]interface{}) (*bootResource, error) {
 		type_:        valid["type"].(string),
 		architecture: valid["architecture"].(string),
 		subArches:    valid["subarches"].(string),
-		kernelFlavor: valid["kflavor"].(string),
+		kernelFlavor: kflavor,
 	}
 	return result, nil
 }

--- a/bootresource_test.go
+++ b/bootresource_test.go
@@ -23,7 +23,7 @@ func (*bootResourceSuite) TestReadBootResourcesBadSchema(c *gc.C) {
 func (*bootResourceSuite) TestReadBootResources(c *gc.C) {
 	bootResources, err := readBootResources(twoDotOh, parseJSON(c, bootResourcesResponse))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(bootResources, gc.HasLen, 5)
+	c.Assert(bootResources, gc.HasLen, 6)
 	trusty := bootResources[0]
 
 	subarches := set.NewStrings("generic", "hwe-p", "hwe-q", "hwe-r", "hwe-s", "hwe-t")
@@ -33,6 +33,9 @@ func (*bootResourceSuite) TestReadBootResources(c *gc.C) {
 	c.Assert(trusty.Architecture(), gc.Equals, "amd64/hwe-t")
 	c.Assert(trusty.SubArchitectures(), jc.DeepEquals, subarches)
 	c.Assert(trusty.KernelFlavor(), gc.Equals, "generic")
+
+	centos := bootResources[5]
+	c.Assert(centos.KernelFlavor(), gc.Equals, "")
 }
 
 func (*bootResourceSuite) TestLowVersion(c *gc.C) {
@@ -43,7 +46,7 @@ func (*bootResourceSuite) TestLowVersion(c *gc.C) {
 func (*bootResourceSuite) TestHighVersion(c *gc.C) {
 	bootResources, err := readBootResources(version.MustParse("2.1.9"), parseJSON(c, bootResourcesResponse))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(bootResources, gc.HasLen, 5)
+	c.Assert(bootResources, gc.HasLen, 6)
 }
 
 var bootResourcesResponse = `
@@ -92,6 +95,15 @@ var bootResourcesResponse = `
         "name": "ubuntu/xenial",
         "id": 2,
         "resource_uri": "/MAAS/api/2.0/boot-resources/2/"
+    },
+    {
+        "type": "Generated",
+        "architecture": "amd64/generic",
+        "resource_uri": "/MAAS/api/2.0/boot-resources/6/",
+        "name": "centos/centos7",
+        "title": "",
+        "subarches": "generic",
+        "id": 6
     }
 ]
 `

--- a/controller_test.go
+++ b/controller_test.go
@@ -135,7 +135,7 @@ func (s *controllerSuite) TestBootResources(c *gc.C) {
 	controller := s.getController(c)
 	resources, err := controller.BootResources()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(resources, gc.HasLen, 5)
+	c.Assert(resources, gc.HasLen, 6)
 }
 
 func (s *controllerSuite) TestDevices(c *gc.C) {


### PR DESCRIPTION
Uploading a CentOS7 image and then requesting boot resources will give
an element with no "kflavor" attribute, which causes this error in juju
bootstrap: https://bugs.launchpad.net/juju-core/+bug/1575768

Set it to "" when it's not present in the JSON.
