### PR TITLE
Make kflavor optional

### DIFF
--- a/bootresource.go
+++ b/bootresource.go
@@ -110,7 +110,10 @@ func bootResource_2_0(source map[string]interface{}) (*bootResource, error) {
 		"subarches":    schema.String(),
 		"kflavor":      schema.String(),
 	}
-	checker := schema.FieldMap(fields, nil) // no defaults
+	defaults := schema.Defaults{
+		"kflavor": "",
+	}
+	checker := schema.FieldMap(fields, defaults)
 	coerced, err := checker.Coerce(source, nil)
 	if err != nil {
 		return nil, WrapWithDeserializationError(err, "boot resource 2.0 schema check failed")

--- a/bootresource_test.go
+++ b/bootresource_test.go
@@ -61,7 +61,6 @@ var bootResourcesResponse = `
         "architecture": "amd64/hwe-u",
         "type": "Synced",
         "subarches": "generic,hwe-p,hwe-q,hwe-r,hwe-s,hwe-t,hwe-u",
-        "kflavor": "generic",
         "name": "ubuntu/trusty",
         "id": 1,
         "resource_uri": "/MAAS/api/2.0/boot-resources/1/"


### PR DESCRIPTION
MAAS 2 does not include kflavor in centos boot-resources output. See: https://bugs.launchpad.net/juju-core/+bug/1575768
