### PR TITLE
Make model optional in blockdevice schema

### DIFF
--- a/blockdevice.go
+++ b/blockdevice.go
@@ -130,7 +130,7 @@ func blockdevice_2_0(source map[string]interface{}) (*blockdevice, error) {
 
 		"id":       schema.ForceInt(),
 		"name":     schema.String(),
-		"model":    schema.String(),
+		"model":    schema.OneOf(schema.Nil(""), schema.String()),
 		"path":     schema.String(),
 		"used_for": schema.String(),
 		"tags":     schema.List(schema.String()),
@@ -155,12 +155,13 @@ func blockdevice_2_0(source map[string]interface{}) (*blockdevice, error) {
 		return nil, errors.Trace(err)
 	}
 
+	model, _ := valid["model"].(string)
 	result := &blockdevice{
 		resourceURI: valid["resource_uri"].(string),
 
 		id:      valid["id"].(int),
 		name:    valid["name"].(string),
-		model:   valid["model"].(string),
+		model:   model,
 		path:    valid["path"].(string),
 		usedFor: valid["used_for"].(string),
 		tags:    convertToStringSlice(valid["tags"]),

--- a/blockdevice_test.go
+++ b/blockdevice_test.go
@@ -82,7 +82,7 @@ var blockdevicesResponse = `
         "id_path": "/dev/disk/by-id/ata-QEMU_HARDDISK_QM00001",
         "resource_uri": "/MAAS/api/2.0/nodes/4y3ha3/blockdevices/34/",
         "id": 34,
-        "serial": "QM00001",
+        "serial": null,
         "type": "physical",
         "block_size": 4096,
         "used_size": 8586788864,
@@ -90,7 +90,7 @@ var blockdevicesResponse = `
         "partition_table_type": "MBR",
         "uuid": null,
         "size": 8589934592,
-        "model": "QEMU HARDDISK",
+        "model": null,
         "tags": [
             "rotary"
         ]

--- a/blockdevice_test.go
+++ b/blockdevice_test.go
@@ -42,6 +42,15 @@ func (*blockdeviceSuite) TestReadBlockDevices(c *gc.C) {
 	c.Check(partition.UsedFor(), gc.Equals, "ext4 formatted filesystem mounted at /")
 }
 
+func (*blockdeviceSuite) TestReadBlockDevicesWithNulls(c *gc.C) {
+	blockdevices, err := readBlockDevices(twoDotOh, parseJSON(c, blockdevicesWithNullsResponse))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(blockdevices, gc.HasLen, 1)
+	blockdevice := blockdevices[0]
+
+	c.Check(blockdevice.Model(), gc.Equals, "")
+}
+
 func (*blockdeviceSuite) TestLowVersion(c *gc.C) {
 	_, err := readBlockDevices(version.MustParse("1.9.0"), parseJSON(c, blockdevicesResponse))
 	c.Assert(err, jc.Satisfies, IsUnsupportedVersionError)
@@ -82,7 +91,7 @@ var blockdevicesResponse = `
         "id_path": "/dev/disk/by-id/ata-QEMU_HARDDISK_QM00001",
         "resource_uri": "/MAAS/api/2.0/nodes/4y3ha3/blockdevices/34/",
         "id": 34,
-        "serial": null,
+        "serial": "QM00001",
         "type": "physical",
         "block_size": 4096,
         "used_size": 8586788864,
@@ -90,10 +99,35 @@ var blockdevicesResponse = `
         "partition_table_type": "MBR",
         "uuid": null,
         "size": 8589934592,
-        "model": null,
+        "model": "QEMU HARDDISK",
         "tags": [
             "rotary"
         ]
+    }
+]
+`
+
+var blockdevicesWithNullsResponse = `
+[
+    {
+        "path": "/dev/disk/by-dname/sda",
+        "name": "sda",
+        "used_for": "MBR partitioned with 1 partition",
+        "partitions": [],
+        "filesystem": null,
+        "id_path": null,
+        "resource_uri": "/MAAS/api/2.0/nodes/4y3ha3/blockdevices/34/",
+        "id": 34,
+        "serial": null,
+        "type": "physical",
+        "block_size": 4096,
+        "used_size": 8586788864,
+        "available_size": 0,
+        "partition_table_type": null,
+        "uuid": null,
+        "size": 8589934592,
+        "model": null,
+        "tags": []
     }
 ]
 `


### PR DESCRIPTION
MAAS2 sometimes sends null for the "model" field in blockdevice.
