### PR TITLE
MAAS2: handle fields that might be missing or null from the API

### DIFF
--- a/bootresource.go
+++ b/bootresource.go
@@ -111,7 +111,8 @@ func bootResource_2_0(source map[string]interface{}) (*bootResource, error) {
 		"kflavor":      schema.String(),
 	}
 	defaults := schema.Defaults{
-		"kflavor": "",
+		"subarches": "",
+		"kflavor":   "",
 	}
 	checker := schema.FieldMap(fields, defaults)
 	coerced, err := checker.Coerce(source, nil)

--- a/bootresource_test.go
+++ b/bootresource_test.go
@@ -77,7 +77,6 @@ var bootResourcesResponse = `
     {
         "architecture": "amd64/hwe-w",
         "type": "Synced",
-        "subarches": "generic,hwe-p,hwe-q,hwe-r,hwe-s,hwe-t,hwe-u,hwe-v,hwe-w",
         "kflavor": "generic",
         "name": "ubuntu/trusty",
         "id": 4,

--- a/interface.go
+++ b/interface.go
@@ -381,9 +381,9 @@ func interface_2_0(source map[string]interface{}) (*interface_, error) {
 		"name":    schema.String(),
 		"type":    schema.String(),
 		"enabled": schema.Bool(),
-		"tags":    schema.List(schema.String()),
+		"tags":    schema.OneOf(schema.Nil(""), schema.List(schema.String())),
 
-		"vlan":  schema.StringMap(schema.Any()),
+		"vlan":  schema.OneOf(schema.Nil(""), schema.StringMap(schema.Any())),
 		"links": schema.List(schema.StringMap(schema.Any())),
 
 		"mac_address":   schema.OneOf(schema.Nil(""), schema.String()),
@@ -404,10 +404,15 @@ func interface_2_0(source map[string]interface{}) (*interface_, error) {
 	// From here we know that the map returned from the schema coercion
 	// contains fields of the right type.
 
-	vlan, err := vlan_2_0(valid["vlan"].(map[string]interface{}))
-	if err != nil {
-		return nil, errors.Trace(err)
+	var vlan *vlan
+	// If it's not an attribute map then we know it's nil from the schema check.
+	if vlan_map, ok := valid["vlan"].(map[string]interface{}); ok {
+		vlan, err = vlan_2_0(vlan_map)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
+
 	links, err := readLinkList(valid["links"].([]interface{}), link_2_0)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/interface.go
+++ b/interface.go
@@ -406,8 +406,8 @@ func interface_2_0(source map[string]interface{}) (*interface_, error) {
 
 	var vlan *vlan
 	// If it's not an attribute map then we know it's nil from the schema check.
-	if vlan_map, ok := valid["vlan"].(map[string]interface{}); ok {
-		vlan, err = vlan_2_0(vlan_map)
+	if vlanMap, ok := valid["vlan"].(map[string]interface{}); ok {
+		vlan, err = vlan_2_0(vlanMap)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/interface_test.go
+++ b/interface_test.go
@@ -38,6 +38,15 @@ func (*interfaceSuite) TestReadInterfacesBadSchema(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `interface 0: interface 2.0 schema check failed: .*`)
 }
 
+func (*interfaceSuite) TestReadInterfacesNulls(c *gc.C) {
+	iface, err := readInterface(twoDotOh, parseJSON(c, interfaceNullsResponse))
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(iface.MACAddress(), gc.Equals, "")
+	c.Check(iface.Tags(), jc.DeepEquals, []string{})
+	c.Check(iface.VLAN(), gc.IsNil)
+}
+
 func (s *interfaceSuite) checkInterface(c *gc.C, iface *interface_) {
 	c.Check(iface.ID(), gc.Equals, 40)
 	c.Check(iface.Name(), gc.Equals, "eth0")
@@ -410,6 +419,50 @@ const (
     "type": "physical",
     "resource_uri": "/MAAS/api/2.0/nodes/4y3ha6/interfaces/40/",
     "tags": ["foo", "bar"],
+    "links": [
+        {
+            "id": 69,
+            "mode": "auto",
+            "subnet": {
+                "resource_uri": "/MAAS/api/2.0/subnets/1/",
+                "id": 1,
+                "rdns_mode": 2,
+                "vlan": {
+                    "resource_uri": "/MAAS/api/2.0/vlans/1/",
+                    "id": 1,
+                    "secondary_rack": null,
+                    "mtu": 1500,
+                    "primary_rack": "4y3h7n",
+                    "name": "untagged",
+                    "fabric": "fabric-0",
+                    "dhcp_on": true,
+                    "vid": 0
+                },
+                "dns_servers": [],
+                "space": "space-0",
+                "name": "192.168.100.0/24",
+                "gateway_ip": "192.168.100.1",
+                "cidr": "192.168.100.0/24"
+            }
+        }
+    ]
+}
+`
+	interfaceNullsResponse = `
+{
+    "effective_mtu": 1500,
+    "mac_address": null,
+    "children": ["eth0.1", "eth0.2"],
+    "discovered": [],
+    "params": "some params",
+    "vlan": null,
+    "name": "eth0",
+    "enabled": true,
+    "parents": ["bond0"],
+    "id": 40,
+    "type": "physical",
+    "resource_uri": "/MAAS/api/2.0/nodes/4y3ha6/interfaces/40/",
+    "tags": null,
     "links": [
         {
             "id": 69,

--- a/machine_test.go
+++ b/machine_test.go
@@ -89,14 +89,19 @@ func (*machineSuite) TestReadMachines(c *gc.C) {
 	c.Assert(machine.PhysicalBlockDevice(id+5), gc.IsNil)
 }
 
-func (*machineSuite) TestReadMachinesNilArch(c *gc.C) {
+func (*machineSuite) TestReadMachinesNilValues(c *gc.C) {
 	json := parseJSON(c, machinesResponse)
-	json.([]interface{})[0].(map[string]interface{})["architecture"] = nil
+	data := json.([]interface{})[0].(map[string]interface{})
+	data["architecture"] = nil
+	data["status_message"] = nil
+	data["boot_interface"] = nil
 	machines, err := readMachines(twoDotOh, json)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.HasLen, 3)
 	machine := machines[0]
 	c.Check(machine.Architecture(), gc.Equals, "")
+	c.Check(machine.StatusMessage(), gc.Equals, "")
+	c.Check(machine.BootInterface(), gc.IsNil)
 }
 
 func (*machineSuite) TestLowVersion(c *gc.C) {


### PR DESCRIPTION
I asked the MAAS team to look through a list of all the fields that we're using in the MAAS v2 API and tell us which of them were optional or nullable. These changes are based on the information they gave us back. 

Based on the spreadsheet here: https://docs.google.com/a/canonical.com/spreadsheets/d/1qysFkvJwz3w19B3kYcnlokwqdTb82HGCrF4pUk6gtfA/edit?usp=sharing
