### PR TITLE
Enable reading and setting machine owner data

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -252,6 +252,21 @@ type MachinesArgs struct {
 	Domain       string
 	Zone         string
 	AgentName    string
+	Tags         map[string]string
+}
+
+func (a *MachinesArgs) Validate() error {
+	hasTags := len(a.Tags) > 0
+	hasOtherFields := len(a.Hostnames) > 0 ||
+		len(a.MACAddresses) > 0 ||
+		len(a.SystemIDs) > 0 ||
+		a.Domain != "" ||
+		a.Zone != "" ||
+		a.AgentName != ""
+	if hasTags && hasOtherFields {
+		return errors.NotSupportedf("searching by tags with other filters")
+	}
+	return nil
 }
 
 // Machines implements Controller.

--- a/controller_test.go
+++ b/controller_test.go
@@ -264,6 +264,18 @@ func (s *controllerSuite) TestMachinesArgs(c *gc.C) {
 	c.Assert(request.URL.Query(), gc.HasLen, 6)
 }
 
+func (s *controllerSuite) TestMachinesArgsValidate(c *gc.C) {
+	args := MachinesArgs{
+		Hostnames: []string{"helpful-bear"},
+		Tags: map[string]string{
+			"juju-model":         "aaa-bbb",
+			"juju-is-controller": "true",
+		},
+	}
+	err := args.Validate()
+	c.Assert(err, gc.ErrorMatches, "searching by tags with other filters not supported")
+}
+
 func (s *controllerSuite) TestStorageSpec(c *gc.C) {
 	for i, test := range []struct {
 		spec StorageSpec

--- a/interfaces.go
+++ b/interfaces.go
@@ -177,6 +177,8 @@ type Device interface {
 
 // Machine represents a physical machine.
 type Machine interface {
+	OwnerDataHolder
+
 	SystemID() string
 	Hostname() string
 	FQDN() string
@@ -342,4 +344,19 @@ type BlockDevice interface {
 
 	// There are some other attributes for block devices, but we can
 	// expose them on an as needed basis.
+}
+
+// OwnerDataHolder represents any MAAS object that can store key/value
+// data.
+type OwnerDataHolder interface {
+	// OwnerData returns a copy of the key/value data stored for this
+	// object.
+	OwnerData() map[string]string
+
+	// SetOwnerData updates the key/value data stored for this object
+	// with the values passed in. Existing keys that aren't specified
+	// in the map passed in will be left in place; to clear a key set
+	// its value to "". All owner data is cleared when the object is
+	// released.
+	SetOwnerData(map[string]string) error
 }

--- a/machine.go
+++ b/machine.go
@@ -16,10 +16,11 @@ type machine struct {
 
 	resourceURI string
 
-	systemID string
-	hostname string
-	fqdn     string
-	tags     []string
+	systemID  string
+	hostname  string
+	fqdn      string
+	tags      []string
+	ownerData map[string]string
 
 	operatingSystem string
 	distroSeries    string
@@ -57,6 +58,8 @@ func (m *machine) updateFrom(other *machine) {
 	m.statusName = other.statusName
 	m.statusMessage = other.statusMessage
 	m.zone = other.zone
+	m.tags = other.tags
+	m.ownerData = other.ownerData
 }
 
 // SystemID implements Machine.
@@ -326,6 +329,20 @@ func (m *machine) CreateDevice(args CreateMachineDeviceArgs) (_ Device, err erro
 	return device, nil
 }
 
+// OwnerData implements OwnerDataHolder.
+func (m *machine) OwnerData() map[string]string {
+	result := make(map[string]string)
+	for key, value := range m.ownerData {
+		result[key] = value
+	}
+	return result
+}
+
+// SetOwnerData implements OwnerDataHolder.
+func (m *machine) SetOwnerData(ownerData map[string]string) error {
+	return nil
+}
+
 func readMachine(controllerVersion version.Number, source interface{}) (*machine, error) {
 	readFunc, err := getMachineDeserializationFunc(controllerVersion)
 	if err != nil {
@@ -395,10 +412,11 @@ func machine_2_0(source map[string]interface{}) (*machine, error) {
 	fields := schema.Fields{
 		"resource_uri": schema.String(),
 
-		"system_id": schema.String(),
-		"hostname":  schema.String(),
-		"fqdn":      schema.String(),
-		"tag_names": schema.List(schema.String()),
+		"system_id":  schema.String(),
+		"hostname":   schema.String(),
+		"fqdn":       schema.String(),
+		"tag_names":  schema.List(schema.String()),
+		"owner_data": schema.StringMap(schema.String()),
 
 		"osystem":       schema.String(),
 		"distro_series": schema.String(),
@@ -459,10 +477,11 @@ func machine_2_0(source map[string]interface{}) (*machine, error) {
 	result := &machine{
 		resourceURI: valid["resource_uri"].(string),
 
-		systemID: valid["system_id"].(string),
-		hostname: valid["hostname"].(string),
-		fqdn:     valid["fqdn"].(string),
-		tags:     convertToStringSlice(valid["tag_names"]),
+		systemID:  valid["system_id"].(string),
+		hostname:  valid["hostname"].(string),
+		fqdn:      valid["fqdn"].(string),
+		tags:      convertToStringSlice(valid["tag_names"]),
+		ownerData: convertToStringMap(valid["owner_data"]),
 
 		operatingSystem: valid["osystem"].(string),
 		distroSeries:    valid["distro_series"].(string),
@@ -493,6 +512,18 @@ func convertToStringSlice(field interface{}) []string {
 	result := make([]string, len(fieldSlice))
 	for i, value := range fieldSlice {
 		result[i] = value.(string)
+	}
+	return result
+}
+
+func convertToStringMap(field interface{}) map[string]string {
+	if field == nil {
+		return nil
+	}
+	fieldMap := field.(map[string]interface{})
+	result := make(map[string]string)
+	for key, value := range fieldMap {
+		result[key] = value.(string)
 	}
 	return result
 }

--- a/machine.go
+++ b/machine.go
@@ -534,6 +534,8 @@ func convertToStringMap(field interface{}) map[string]string {
 	if field == nil {
 		return nil
 	}
+	// This function is only called after a schema Coerce, so it's
+	// safe.
 	fieldMap := field.(map[string]interface{})
 	result := make(map[string]string)
 	for key, value := range fieldMap {

--- a/machine.go
+++ b/machine.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/schema"
 	"github.com/juju/version"
+	"net/url"
 )
 
 type machine struct {
@@ -340,6 +341,19 @@ func (m *machine) OwnerData() map[string]string {
 
 // SetOwnerData implements OwnerDataHolder.
 func (m *machine) SetOwnerData(ownerData map[string]string) error {
+	params := make(url.Values)
+	for key, value := range ownerData {
+		params.Add(key, value)
+	}
+	result, err := m.controller.post(m.resourceURI, "set-owner-data", params)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	machine, err := readMachine(m.controller.apiVersion, result)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	m.updateFrom(machine)
 	return nil
 }
 

--- a/testing.go
+++ b/testing.go
@@ -158,7 +158,7 @@ func (s *SimpleTestServer) RequestCount() int {
 }
 
 func (s *SimpleTestServer) ResetRequests() {
-	s.requests = []*http.Request{}
+	s.requests = nil
 }
 
 func (s *SimpleTestServer) handler(writer http.ResponseWriter, request *http.Request) {

--- a/testing.go
+++ b/testing.go
@@ -145,8 +145,20 @@ func (s *SimpleTestServer) LastRequest() *http.Request {
 	return s.requests[pos]
 }
 
+func (s *SimpleTestServer) LastNRequests(n int) []*http.Request {
+	start := len(s.requests) - n
+	if start < 0 {
+		start = 0
+	}
+	return s.requests[start:]
+}
+
 func (s *SimpleTestServer) RequestCount() int {
 	return len(s.requests)
+}
+
+func (s *SimpleTestServer) ResetRequests() {
+	s.requests = []*http.Request{}
 }
 
 func (s *SimpleTestServer) handler(writer http.ResponseWriter, request *http.Request) {


### PR DESCRIPTION
Expose owner data from the API - this is key/value storage that can be set by the owner of the machine and is cleared when the machine is released.

It's needed so Juju can to store controller/model information for instances without using the Storage interface.
