### PR TITLE
Machine.CreateDevice() - added VLAN to args; only use args.Subnet/VLAN if set

### DIFF
--- a/interface_test.go
+++ b/interface_test.go
@@ -152,11 +152,21 @@ func (s *interfaceSuite) TestDeleteUnknown(c *gc.C) {
 
 type fakeSubnet struct {
 	Subnet
-	id int
+	id   int
+	cidr string
+	vlan VLAN
 }
 
 func (f *fakeSubnet) ID() int {
 	return f.id
+}
+
+func (f *fakeSubnet) CIDR() string {
+	return f.cidr
+}
+
+func (f *fakeSubnet) VLAN() VLAN {
+	return f.vlan
 }
 
 func (s *interfaceSuite) TestLinkSubnetArgs(c *gc.C) {


### PR DESCRIPTION
With the MAAS 2.0 API code path, Machine.CreateDevice() was modified slightly:
- Added a VLAN field to CreateDeviceArgs (optional)
- Made args.Subnet optional, only used if set.
- When both Subnet and VLAN are set, CreateDevice() validates they match.

Needed in order to fix the following juju bug: http://pad.lv/1566791
There's nothing wrong with devices having unconfigured primary interface.
