### PR TITLE
machine: Fix panic if primary device NIC's VLAN is nil

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -342,10 +342,9 @@ func (m *machine) CreateDevice(args CreateMachineDeviceArgs) (_ Device, err erro
 
 func (m *machine) updateDeviceInterface(iface Interface, nameToUse string, vlanToUse VLAN) error {
 	updateArgs := UpdateInterfaceArgs{}
-	if iface.Name() != nameToUse {
-		updateArgs.Name = nameToUse
-	}
-	if vlanToUse != nil && iface.VLAN().ID() != vlanToUse.ID() {
+	updateArgs.Name = nameToUse
+
+	if vlanToUse != nil {
 		updateArgs.VLAN = vlanToUse
 	}
 


### PR DESCRIPTION
An odd corner case was discovered, which might cause the primary (and
only) NIC of a newly created device to have a nil VLAN, which causes a
panic in juju/state: http://paste.ubuntu.com/23203930

Tested manually on MAAS 2.0 and 2.1a3 (incl. by external stakeholders)
