### PR TITLE
Expose the StaticRoutes API

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -154,7 +154,19 @@ func (c *controller) Spaces() ([]Space, error) {
 
 // StaticRoutes implements Controller.
 func (c *controller) StaticRoutes() ([]StaticRoute, error) {
-	return nil, nil
+	source, err := c.get("static-routes")
+	if err != nil {
+		return nil, NewUnexpectedError(err)
+	}
+	staticRoutes, err := readStaticRoutes(c.apiVersion, source)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	var result []StaticRoute
+	for _, staticRoute := range staticRoutes {
+		result = append(result, staticRoute)
+	}
+	return result, nil
 }
 
 // Zones implements Controller.

--- a/controller.go
+++ b/controller.go
@@ -152,6 +152,11 @@ func (c *controller) Spaces() ([]Space, error) {
 	return result, nil
 }
 
+// StaticRoutes implements Controller.
+func (c *controller) StaticRoutes() ([]StaticRoute, error) {
+	return nil, nil
+}
+
 // Zones implements Controller.
 func (c *controller) Zones() ([]Zone, error) {
 	source, err := c.get("zones")

--- a/controller_test.go
+++ b/controller_test.go
@@ -49,6 +49,7 @@ func (s *controllerSuite) SetUpTest(c *gc.C) {
 	server.AddGetResponse("/api/2.0/machines/", http.StatusOK, machinesResponse)
 	server.AddGetResponse("/api/2.0/machines/?hostname=untasted-markita", http.StatusOK, "["+machineResponse+"]")
 	server.AddGetResponse("/api/2.0/spaces/", http.StatusOK, spacesResponse)
+	server.AddGetResponse("/api/2.0/static-routes/", http.StatusOK, staticRoutesResponse)
 	server.AddGetResponse("/api/2.0/users/?op=whoami", http.StatusOK, `"captain awesome"`)
 	server.AddGetResponse("/api/2.0/version/", http.StatusOK, versionResponse)
 	server.AddGetResponse("/api/2.0/zones/", http.StatusOK, zoneResponse)
@@ -220,6 +221,13 @@ func (s *controllerSuite) TestSpaces(c *gc.C) {
 	spaces, err := controller.Spaces()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(spaces, gc.HasLen, 1)
+}
+
+func (s *controllerSuite) TestStaticRoutes(c *gc.C) {
+	controller := s.getController(c)
+	staticRoutes, err := controller.StaticRoutes()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(staticRoutes, gc.HasLen, 1)
 }
 
 func (s *controllerSuite) TestZones(c *gc.C) {

--- a/interfaces.go
+++ b/interfaces.go
@@ -32,6 +32,9 @@ type Controller interface {
 	// Spaces returns the list of Spaces defined in the MAAS controller.
 	Spaces() ([]Space, error)
 
+	// StaticRoutes returns the list of StaticRoutes defined in the MAAS controller.
+	StaticRoutes() ([]StaticRoute, error)
+
 	// Zones lists all the zones known to the MAAS controller.
 	Zones() ([]Zone, error)
 
@@ -252,6 +255,24 @@ type Subnet interface {
 	// DNSServers is a list of ip addresses of the DNS servers for the subnet.
 	// This list may be empty.
 	DNSServers() []string
+}
+
+// StaticRoute defines an explicit route that users have requested to be added
+// for a given subnet.
+type StaticRoute interface {
+	// Source is the subnet that should have the route configured. (Machines
+	// inside Source should use GatewayIP to reach Destination addresses.)
+	Source() Subnet
+	// Destination is the subnet that a machine wants to send packets to. We
+	// want to configure a route to that subnet via GatewayIP
+	Destination() Subnet
+	// GatewayIP is the IPAddress of the
+	GatewayIP() string
+	// Metric is the routing metric that determines whether this route will
+	// take precedence over similar routes (there may be a route for 10/8, but
+	// also a more concrete route for 10.0/16 that should take precedence if it
+	// applies.) Metric should be a non-negative integer.
+	Metric() int
 }
 
 // Interface represents a physical or virtual network interface on a Machine.

--- a/interfaces.go
+++ b/interfaces.go
@@ -264,9 +264,9 @@ type StaticRoute interface {
 	// inside Source should use GatewayIP to reach Destination addresses.)
 	Source() Subnet
 	// Destination is the subnet that a machine wants to send packets to. We
-	// want to configure a route to that subnet via GatewayIP
+	// want to configure a route to that subnet via GatewayIP.
 	Destination() Subnet
-	// GatewayIP is the IPAddress of the
+	// GatewayIP is the IPAddress to direct traffic to.
 	GatewayIP() string
 	// Metric is the routing metric that determines whether this route will
 	// take precedence over similar routes (there may be a route for 10/8, but

--- a/staticroute.go
+++ b/staticroute.go
@@ -1,0 +1,133 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package gomaasapi
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/schema"
+	"github.com/juju/version"
+)
+
+type staticRoute struct {
+	// Add the controller in when we need to do things with the staticRoute.
+	// controller Controller
+
+	resourceURI string
+
+	id          int
+	source      *subnet
+	destination *subnet
+	gatewayIP   string
+	metric      int
+}
+
+// Id implements StaticRoute.
+func (s *staticRoute) ID() int {
+	return s.id
+}
+
+// Source implements StaticRoute.
+func (s *staticRoute) Source() Subnet {
+	return s.source
+}
+
+// Destination implements StaticRoute.
+func (s *staticRoute) Destination() Subnet {
+	return s.destination
+}
+
+// GatewayIP implements StaticRoute.
+func (s *staticRoute) GatewayIP() string {
+	return s.gatewayIP
+}
+
+// Metric implements StaticRoute.
+func (s *staticRoute) Metric() int {
+	return s.metric
+}
+
+func readStaticRoutes(controllerVersion version.Number, source interface{}) ([]*staticRoute, error) {
+	checker := schema.List(schema.StringMap(schema.Any()))
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "static-route base schema check failed")
+	}
+	valid := coerced.([]interface{})
+
+	var deserialisationVersion version.Number
+	for v := range staticRouteDeserializationFuncs {
+		if v.Compare(deserialisationVersion) > 0 && v.Compare(controllerVersion) <= 0 {
+			deserialisationVersion = v
+		}
+	}
+	if deserialisationVersion == version.Zero {
+		return nil, errors.Errorf("no static-route read func for version %s", controllerVersion)
+	}
+	readFunc := staticRouteDeserializationFuncs[deserialisationVersion]
+	return readStaticRouteList(valid, readFunc)
+}
+
+// readStaticRouteList expects the values of the sourceList to be string maps.
+func readStaticRouteList(sourceList []interface{}, readFunc staticRouteDeserializationFunc) ([]*staticRoute, error) {
+	result := make([]*staticRoute, 0, len(sourceList))
+	for i, value := range sourceList {
+		source, ok := value.(map[string]interface{})
+		if !ok {
+			return nil, errors.Errorf("unexpected value for static-route %d, %T", i, value)
+		}
+		staticRoute, err := readFunc(source)
+		if err != nil {
+			return nil, errors.Annotatef(err, "static-route %d", i)
+		}
+		result = append(result, staticRoute)
+	}
+	return result, nil
+}
+
+type staticRouteDeserializationFunc func(map[string]interface{}) (*staticRoute, error)
+
+var staticRouteDeserializationFuncs = map[version.Number]staticRouteDeserializationFunc{
+	twoDotOh: staticRoute_2_0,
+}
+
+func staticRoute_2_0(source map[string]interface{}) (*staticRoute, error) {
+	fields := schema.Fields{
+		"resource_uri": schema.String(),
+		"id":           schema.ForceInt(),
+		"source":         schema.StringMap(schema.Any()),
+		"destination":      schema.StringMap(schema.Any()),
+		"gateway_ip":           schema.String(),
+		"metric":		schema.ForceInt(),
+	}
+	checker := schema.FieldMap(fields, nil) // no defaults
+	coerced, err := checker.Coerce(source, nil)
+	if err != nil {
+		return nil, errors.Annotatef(err, "static-route 2.0 schema check failed")
+	}
+	valid := coerced.(map[string]interface{})
+	// From here we know that the map returned from the schema coercion
+	// contains fields of the right type.
+
+	// readSubnetList takes a list of interfaces. We happen to have 2 subnets
+	// to parse, that are in different keys, but we might as well wrap them up
+	// together and pass them in.
+	subnets, err := readSubnetList([]interface{}{valid["source"], valid["destination"]}, subnet_2_0)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(subnets) != 2 {
+		// how could we get here?
+		return nil, errors.Errorf("subnets somehow parsed into the wrong number of items (expected 2): %d", len(subnets))
+	}
+
+	result := &staticRoute{
+		resourceURI: valid["resource_uri"].(string),
+		id:          valid["id"].(int),
+		gatewayIP: valid["gateway_ip"].(string),
+		metric: valid["metric"].(int),
+		source: subnets[0],
+		destination: subnets[1],
+	}
+	return result, nil
+}

--- a/staticroute.go
+++ b/staticroute.go
@@ -10,9 +10,6 @@ import (
 )
 
 type staticRoute struct {
-	// Add the controller in when we need to do things with the staticRoute.
-	// controller Controller
-
 	resourceURI string
 
 	id          int

--- a/staticroute.go
+++ b/staticroute.go
@@ -95,10 +95,10 @@ func staticRoute_2_0(source map[string]interface{}) (*staticRoute, error) {
 	fields := schema.Fields{
 		"resource_uri": schema.String(),
 		"id":           schema.ForceInt(),
-		"source":         schema.StringMap(schema.Any()),
-		"destination":      schema.StringMap(schema.Any()),
-		"gateway_ip":           schema.String(),
-		"metric":		schema.ForceInt(),
+		"source":       schema.StringMap(schema.Any()),
+		"destination":  schema.StringMap(schema.Any()),
+		"gateway_ip":   schema.String(),
+		"metric":       schema.ForceInt(),
 	}
 	checker := schema.FieldMap(fields, nil) // no defaults
 	coerced, err := checker.Coerce(source, nil)
@@ -124,9 +124,9 @@ func staticRoute_2_0(source map[string]interface{}) (*staticRoute, error) {
 	result := &staticRoute{
 		resourceURI: valid["resource_uri"].(string),
 		id:          valid["id"].(int),
-		gatewayIP: valid["gateway_ip"].(string),
-		metric: valid["metric"].(int),
-		source: subnets[0],
+		gatewayIP:   valid["gateway_ip"].(string),
+		metric:      valid["metric"].(int),
+		source:      subnets[0],
 		destination: subnets[1],
 	}
 	return result, nil

--- a/staticroute_test.go
+++ b/staticroute_test.go
@@ -1,0 +1,112 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package gomaasapi
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version"
+	gc "gopkg.in/check.v1"
+)
+
+type staticRouteSuite struct{}
+
+var _ = gc.Suite(&staticRouteSuite{})
+
+func (*staticRouteSuite) TestReadStaticRoutesBadSchema(c *gc.C) {
+	_, err := readStaticRoutes(twoDotOh, "wat?")
+	c.Assert(err.Error(), gc.Equals, `static-route base schema check failed: expected list, got string("wat?")`)
+}
+
+func (*staticRouteSuite) TestReadStaticRoutes(c *gc.C) {
+	staticRoutes, err := readStaticRoutes(twoDotOh, parseJSON(c, staticRoutesResponse))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(staticRoutes, gc.HasLen, 1)
+
+	staticRoute := staticRoutes[0]
+	c.Assert(staticRoute.ID(), gc.Equals, 2)
+	c.Assert(staticRoute.Metric(), gc.Equals, int(0))
+	c.Assert(staticRoute.GatewayIP(), gc.Equals, "192.168.0.1")
+	source := staticRoute.Source()
+	c.Assert(source, gc.NotNil)
+	c.Assert(source.Name(), gc.Equals, "192.168.0.0/24")
+	c.Assert(source.CIDR(), gc.Equals, "192.168.0.0/24")
+	destination := staticRoute.Destination()
+	c.Assert(destination, gc.NotNil)
+	c.Assert(destination.Name(), gc.Equals, "Local-192")
+	c.Assert(destination.CIDR(), gc.Equals, "192.168.0.0/16")
+}
+
+func (*staticRouteSuite) TestLowVersion(c *gc.C) {
+	_, err := readStaticRoutes(version.MustParse("1.9.0"), parseJSON(c, staticRoutesResponse))
+	c.Assert(err.Error(), gc.Equals, `no static-route read func for version 1.9.0`)
+}
+
+func (*staticRouteSuite) TestHighVersion(c *gc.C) {
+	staticRoutes, err := readStaticRoutes(version.MustParse("2.1.9"), parseJSON(c, staticRoutesResponse))
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(staticRoutes, gc.HasLen, 1)
+}
+
+var staticRoutesResponse = `
+[
+    {
+        "destination": {
+            "active_discovery": false,
+            "id": 3,
+            "resource_uri": "/MAAS/api/2.0/subnets/3/",
+            "allow_proxy": true,
+            "rdns_mode": 2,
+            "dns_servers": [
+                "8.8.8.8"
+            ],
+            "name": "Local-192",
+            "cidr": "192.168.0.0/16",
+            "space": "space-0",
+            "vlan": {
+                "fabric": "fabric-1",
+                "id": 5002,
+                "dhcp_on": false,
+                "primary_rack": null,
+                "resource_uri": "/MAAS/api/2.0/vlans/5002/",
+                "mtu": 1500,
+                "fabric_id": 1,
+                "secondary_rack": null,
+                "name": "untagged",
+                "external_dhcp": null,
+                "vid": 0
+            },
+            "gateway_ip": "192.168.0.1"
+        },
+        "source": {
+            "active_discovery": false,
+            "id": 1,
+            "resource_uri": "/MAAS/api/2.0/subnets/1/",
+            "allow_proxy": true,
+            "rdns_mode": 2,
+            "dns_servers": [],
+            "name": "192.168.0.0/24",
+            "cidr": "192.168.0.0/24",
+            "space": "space-0",
+            "vlan": {
+                "fabric": "fabric-0",
+                "id": 5001,
+                "dhcp_on": false,
+                "primary_rack": null,
+                "resource_uri": "/MAAS/api/2.0/vlans/5001/",
+                "mtu": 1500,
+                "fabric_id": 0,
+                "secondary_rack": null,
+                "name": "untagged",
+                "external_dhcp": "192.168.0.1",
+                "vid": 0
+            },
+            "gateway_ip": null
+        },
+        "id": 2,
+        "resource_uri": "/MAAS/api/2.0/static-routes/2/",
+        "metric": 0,
+        "gateway_ip": "192.168.0.1"
+    }
+]
+`

--- a/testservice.go
+++ b/testservice.go
@@ -97,15 +97,15 @@ type TestServer struct {
 	// devices is a map of device UUIDs to devices.
 	devices map[string]*TestDevice
 
-	subnets        map[uint]TestSubnet
-	subnetNameToID map[string]uint
-	nextSubnet     uint
-	spaces         map[uint]*TestSpace
-	spaceNameToID  map[string]uint
-	nextSpace      uint
-	vlans          map[int]TestVLAN
-	nextVLAN       int
-	staticRoutes   map[uint]*TestStaticRoute
+	subnets         map[uint]TestSubnet
+	subnetNameToID  map[string]uint
+	nextSubnet      uint
+	spaces          map[uint]*TestSpace
+	spaceNameToID   map[string]uint
+	nextSpace       uint
+	vlans           map[int]TestVLAN
+	nextVLAN        int
+	staticRoutes    map[uint]*TestStaticRoute
 	nextStaticRoute uint
 }
 

--- a/testservice.go
+++ b/testservice.go
@@ -105,6 +105,8 @@ type TestServer struct {
 	nextSpace      uint
 	vlans          map[int]TestVLAN
 	nextVLAN       int
+	staticRoutes   map[uint]*TestStaticRoute
+	nextStaticRoute uint
 }
 
 type TestDevice struct {
@@ -236,6 +238,8 @@ func (server *TestServer) Clear() {
 	server.nextSpace = 1
 	server.vlans = make(map[int]TestVLAN)
 	server.nextVLAN = 1
+	server.staticRoutes = make(map[uint]*TestStaticRoute)
+	server.nextStaticRoute = 1
 }
 
 // SetVersionJSON sets the JSON response (capabilities) returned from the
@@ -605,6 +609,11 @@ func NewTestServer(version string) *TestServer {
 	spacesURL := getSpacesEndpoint(server.version)
 	serveMux.HandleFunc(spacesURL, func(w http.ResponseWriter, r *http.Request) {
 		spacesHandler(server, w, r)
+	})
+
+	staticRoutesURL := getStaticRoutesEndpoint(server.version)
+	serveMux.HandleFunc(staticRoutesURL, func(w http.ResponseWriter, r *http.Request) {
+		staticRoutesHandler(server, w, r)
 	})
 
 	vlansURL := getVLANsEndpoint(server.version)

--- a/testservice_staticroutes.go
+++ b/testservice_staticroutes.go
@@ -89,8 +89,13 @@ func staticRoutesHandler(server *TestServer, w http.ResponseWriter, r *http.Requ
 		}
 		checkError(err)
 	case "POST":
+		w.WriteHeader(http.StatusNotImplemented)
+		// TODO(jam) 2017-02-23 we could probably wire this into creating a new
+		// static route if we need the support.
 		//server.NewStaticRoute(r.Body)
 	case "PUT":
+		w.WriteHeader(http.StatusNotImplemented)
+		// TODO(jam): 2017-02-23 if we wanted to implement this, something like:
 		//server.UpdateStaticRoute(r.Body)
 	case "DELETE":
 		delete(server.staticRoutes, ID)
@@ -116,7 +121,7 @@ func decodePostedStaticRoute(staticRouteJSON io.Reader) CreateStaticRoute {
 	return postedStaticRoute
 }
 
-// NewStaticRoute creates a Static Route in the test server
+// NewStaticRoute creates a Static Route in the test server.
 func (server *TestServer) NewStaticRoute(staticRouteJSON io.Reader) *TestStaticRoute {
 	postedStaticRoute := decodePostedStaticRoute(staticRouteJSON)
 	// TODO(jam): 2017-02-03 Validate that sourceSubnet and destinationSubnet really do exist

--- a/testservice_staticroutes.go
+++ b/testservice_staticroutes.go
@@ -1,0 +1,152 @@
+// Copyright 2012-2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package gomaasapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+)
+
+func getStaticRoutesEndpoint(version string) string {
+	return fmt.Sprintf("/api/%s/static-routes/", version)
+}
+
+// TestStaticRoute is the MAAS API Static Route representation
+type TestStaticRoute struct {
+	Destination TestSubnet `json:"destination"`
+	Source      TestSubnet `json:"source"`
+	Metric      uint       `json:"metric"`
+	GatewayIP   string     `json:"gateway_ip"`
+	ResourceURI string     `json:"resource_uri"`
+	ID          uint       `json:"id"`
+	// These are internal bookkeeping, and not part of the public API, so
+	// should not be in the JSON
+	sourceCIDR      string `json:"-"`
+	destinationCIDR string `json:"-"`
+}
+
+// staticRoutesHandler handles requests for '/api/<version>/static-routes/'.
+func staticRoutesHandler(server *TestServer, w http.ResponseWriter, r *http.Request) {
+	values, err := url.ParseQuery(r.URL.RawQuery)
+	checkError(err)
+	op := values.Get("op")
+	if op != "" {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	staticRoutesURLRE := regexp.MustCompile(`/static-routes/(.+?)/`)
+	staticRoutesURLMatch := staticRoutesURLRE.FindStringSubmatch(r.URL.Path)
+	staticRoutesURL := getStaticRoutesEndpoint(server.version)
+
+	var ID uint
+	var gotID bool
+	if staticRoutesURLMatch != nil {
+		// We pass a nil mapping, as static routes don't have names, but this gives
+		// consistent integers and range checking.
+		ID, err = NameOrIDToID(staticRoutesURLMatch[1], nil, 1, uint(len(server.staticRoutes)))
+
+		if err != nil {
+			http.NotFoundHandler().ServeHTTP(w, r)
+			return
+		}
+
+		gotID = true
+	}
+
+	switch r.Method {
+	case "GET":
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		if len(server.staticRoutes) == 0 {
+			// Until a static-route is created, behave as if the endpoint
+			// does not exist. This way we can simulate older MAAS
+			// servers that do not support spaces.
+			http.NotFoundHandler().ServeHTTP(w, r)
+			return
+		}
+
+		if r.URL.Path == staticRoutesURL {
+			var routes []*TestStaticRoute
+			// Iterating by id rather than a dictionary iteration
+			// preserves the order of the routes in the result.
+			for i := uint(1); i < server.nextStaticRoute; i++ {
+				route, ok := server.staticRoutes[i]
+				if ok {
+					server.setSubnetsOnStaticRoute(route)
+					routes = append(routes, route)
+				}
+			}
+			err = json.NewEncoder(w).Encode(routes)
+		} else if gotID == false {
+			w.WriteHeader(http.StatusBadRequest)
+		} else {
+			err = json.NewEncoder(w).Encode(server.staticRoutes[ID])
+		}
+		checkError(err)
+	case "POST":
+		//server.NewStaticRoute(r.Body)
+	case "PUT":
+		//server.UpdateStaticRoute(r.Body)
+	case "DELETE":
+		delete(server.staticRoutes, ID)
+		w.WriteHeader(http.StatusOK)
+	default:
+		w.WriteHeader(http.StatusBadRequest)
+	}
+}
+
+// CreateStaticRoute is used to create new Static Routes on the server.
+type CreateStaticRoute struct {
+	SourceCIDR      string `json:"source"`
+	DestinationCIDR string `json:"destination"`
+	GatewayIP       string `json:"gateway_ip"`
+	Metric          uint   `json:"metric"`
+}
+
+func decodePostedStaticRoute(staticRouteJSON io.Reader) CreateStaticRoute {
+	var postedStaticRoute CreateStaticRoute
+	decoder := json.NewDecoder(staticRouteJSON)
+	err := decoder.Decode(&postedStaticRoute)
+	checkError(err)
+	return postedStaticRoute
+}
+
+// NewStaticRoute creates a Static Route in the test server
+func (server *TestServer) NewStaticRoute(staticRouteJSON io.Reader) *TestStaticRoute {
+	postedStaticRoute := decodePostedStaticRoute(staticRouteJSON)
+	// TODO(jam): 2017-02-03 Validate that sourceSubnet and destinationSubnet really do exist
+	// sourceSubnet := blah
+	// destinationSubnet := blah
+	newStaticRoute := &TestStaticRoute{
+		destinationCIDR: postedStaticRoute.DestinationCIDR,
+		sourceCIDR:      postedStaticRoute.SourceCIDR,
+		Metric:          postedStaticRoute.Metric,
+		GatewayIP:       postedStaticRoute.GatewayIP,
+	}
+	newStaticRoute.ID = server.nextStaticRoute
+	newStaticRoute.ResourceURI = fmt.Sprintf("/api/%s/static-routes/%d/", server.version, int(server.nextStaticRoute))
+	server.staticRoutes[server.nextStaticRoute] = newStaticRoute
+
+	server.nextStaticRoute++
+	return newStaticRoute
+}
+
+// setSubnetsOnStaticRoutes fetches the subnets for the specified static route
+// and adds them to it.
+func (server *TestServer) setSubnetsOnStaticRoute(staticRoute *TestStaticRoute) {
+	for i := uint(1); i < server.nextSubnet; i++ {
+		subnet, ok := server.subnets[i]
+		if ok {
+			if subnet.CIDR == staticRoute.sourceCIDR {
+				staticRoute.Source = subnet
+			} else if subnet.CIDR == staticRoute.destinationCIDR {
+				staticRoute.Destination = subnet
+			}
+		}
+	}
+}


### PR DESCRIPTION
This implements support for listing StaticRoutes.
  https://docs.ubuntu.com/maas/2.0/en/api#static-route

The only thing it supports is reading all of them. It doesn't support creating them, or reading just a single one of them. However, that's all we concretely need for Juju's use case. (MaaS doesn't let you look up static routes by source/destination subnets, etc. So we always have to read all of them and then find the ones we care about from there.)

This is necessary to implement Static Route support for containers in Juju:
 https://bugs.launchpad.net/juju/+bug/1653708
