### PR TITLE
controller: Accept a versioned API URL

### DIFF
--- a/client.go
+++ b/client.go
@@ -11,6 +11,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -265,10 +266,12 @@ func (signer anonSigner) OAuthSign(request *http.Request) error {
 // *anonSigner implements the OAuthSigner interface.
 var _ OAuthSigner = anonSigner{}
 
-func composeAPIURL(BaseURL string, apiVersion string) (*url.URL, error) {
+// AddAPIVersionToURL will add the version/<version>/ suffix to the
+// given URL, handling trailing slashes. It shouldn't be called with a
+// URL that already includes a version.
+func AddAPIVersionToURL(BaseURL, apiVersion string) string {
 	baseurl := EnsureTrailingSlash(BaseURL)
-	apiurl := fmt.Sprintf("%sapi/%s/", baseurl, apiVersion)
-	return url.Parse(apiurl)
+	return fmt.Sprintf("%sapi/%s/", baseurl, apiVersion)
 }
 
 // NewAnonymousClient creates a client that issues anonymous requests.
@@ -276,20 +279,21 @@ func composeAPIURL(BaseURL string, apiVersion string) (*url.URL, error) {
 // http://my.maas.server.example.com/MAAS/
 // apiVersion should contain the version of the MAAS API that you want to use.
 func NewAnonymousClient(BaseURL string, apiVersion string) (*Client, error) {
-	parsedBaseURL, err := composeAPIURL(BaseURL, apiVersion)
+	versionedURL := AddAPIVersionToURL(BaseURL, apiVersion)
+	parsedURL, err := url.Parse(versionedURL)
 	if err != nil {
 		return nil, err
 	}
-	return &Client{Signer: &anonSigner{}, APIURL: parsedBaseURL}, nil
+	return &Client{Signer: &anonSigner{}, APIURL: parsedURL}, nil
 }
 
-// NewAuthenticatedClient parses the given MAAS API key into the individual
-// OAuth tokens and creates an Client that will use these tokens to sign the
-// requests it issues.
-// BaseURL should refer to the root of the MAAS server path, e.g.
-// http://my.maas.server.example.com/MAAS/
-// apiVersion should contain the version of the MAAS API that you want to use.
-func NewAuthenticatedClient(BaseURL string, apiKey string, apiVersion string) (*Client, error) {
+// NewAuthenticatedClient parses the given MAAS API key into the
+// individual OAuth tokens and creates an Client that will use these
+// tokens to sign the requests it issues.
+// versionedURL should be the location of the versioned API root of
+// the MAAS server, e.g.:
+// http://my.maas.server.example.com/MAAS/api/2.0/
+func NewAuthenticatedClient(versionedURL, apiKey string) (*Client, error) {
 	elements := strings.Split(apiKey, ":")
 	if len(elements) != 3 {
 		errString := fmt.Sprintf("invalid API key %q; expected \"<consumer secret>:<token key>:<token secret>\"", apiKey)
@@ -306,9 +310,9 @@ func NewAuthenticatedClient(BaseURL string, apiKey string, apiVersion string) (*
 	if err != nil {
 		return nil, err
 	}
-	parsedBaseURL, err := composeAPIURL(BaseURL, apiVersion)
+	parsedURL, err := url.Parse(EnsureTrailingSlash(versionedURL))
 	if err != nil {
 		return nil, err
 	}
-	return &Client{Signer: signer, APIURL: parsedBaseURL}, nil
+	return &Client{Signer: signer, APIURL: parsedURL}, nil
 }

--- a/client.go
+++ b/client.go
@@ -274,6 +274,21 @@ func AddAPIVersionToURL(BaseURL, apiVersion string) string {
 	return fmt.Sprintf("%sapi/%s/", baseurl, apiVersion)
 }
 
+var apiVersionPattern = regexp.MustCompile(`^(?P<base>.*/)api/(?P<version>\d+\.\d+)/?$`)
+
+//splitVersionedURL splits a versioned API URL (like
+//http://maas.server/MAAS/api/2.0/) into a base URL
+//(http://maas.server/MAAS/) and API version (2.0). If the URL doesn't
+//include a version component the bool return value will be false.
+func splitVersionedURL(url string) (string, string, bool) {
+	if !apiVersionPattern.MatchString(url) {
+		return url, "", false
+	}
+	version := apiVersionPattern.ReplaceAllString(url, "$version")
+	baseURL := apiVersionPattern.ReplaceAllString(url, "$base")
+	return baseURL, version, true
+}
+
 // NewAnonymousClient creates a client that issues anonymous requests.
 // BaseURL should refer to the root of the MAAS server path, e.g.
 // http://my.maas.server.example.com/MAAS/

--- a/client_test.go
+++ b/client_test.go
@@ -128,7 +128,7 @@ func (suite *ClientSuite) TestClientdispatchRequestSignsRequest(c *gc.C) {
 	expectedResult := "expected:result"
 	server := newSingleServingServer(URI, expectedResult, http.StatusOK)
 	defer server.Close()
-	client, err := NewAuthenticatedClient(server.URL, "the:api:key", "1.0")
+	client, err := NewAuthenticatedClient(server.URL, "the:api:key")
 	c.Assert(err, jc.ErrorIsNil)
 	request, err := http.NewRequest("GET", server.URL+URI, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -277,7 +277,7 @@ func (suite *ClientSuite) TestNewAnonymousClientEnsuresTrailingSlash(c *gc.C) {
 }
 
 func (suite *ClientSuite) TestNewAuthenticatedClientEnsuresTrailingSlash(c *gc.C) {
-	client, err := NewAuthenticatedClient("http://example.com/", "a:b:c", "1.0")
+	client, err := NewAuthenticatedClient("http://example.com/api/1.0", "a:b:c")
 	c.Assert(err, jc.ErrorIsNil)
 	expectedURL, err := url.Parse("http://example.com/api/1.0/")
 	c.Assert(err, jc.ErrorIsNil)
@@ -293,7 +293,7 @@ func (suite *ClientSuite) TestNewAuthenticatedClientParsesApiKey(c *gc.C) {
 	keyElements := []string{consumerKey, tokenKey, tokenSecret}
 	apiKey := strings.Join(keyElements, ":")
 
-	client, err := NewAuthenticatedClient("http://example.com/", apiKey, "1.0")
+	client, err := NewAuthenticatedClient("http://example.com/api/1.0/", apiKey)
 
 	c.Assert(err, jc.ErrorIsNil)
 	signer := client.Signer.(*plainTextOAuthSigner)
@@ -303,17 +303,15 @@ func (suite *ClientSuite) TestNewAuthenticatedClientParsesApiKey(c *gc.C) {
 }
 
 func (suite *ClientSuite) TestNewAuthenticatedClientFailsIfInvalidKey(c *gc.C) {
-	client, err := NewAuthenticatedClient("", "invalid-key", "1.0")
+	client, err := NewAuthenticatedClient("", "invalid-key")
 
 	c.Check(err, gc.ErrorMatches, "invalid API key.*")
 	c.Check(client, gc.IsNil)
 
 }
 
-func (suite *ClientSuite) TestcomposeAPIURLReturnsURL(c *gc.C) {
-	apiurl, err := composeAPIURL("http://example.com/MAAS", "1.0")
-	c.Assert(err, jc.ErrorIsNil)
-	expectedURL, err := url.Parse("http://example.com/MAAS/api/1.0/")
-	c.Assert(err, jc.ErrorIsNil)
+func (suite *ClientSuite) TestAddAPIVersionToURL(c *gc.C) {
+	apiurl := AddAPIVersionToURL("http://example.com/MAAS", "1.0")
+	expectedURL := "http://example.com/MAAS/api/1.0/"
 	c.Assert(expectedURL, jc.DeepEquals, apiurl)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -311,7 +311,20 @@ func (suite *ClientSuite) TestNewAuthenticatedClientFailsIfInvalidKey(c *gc.C) {
 }
 
 func (suite *ClientSuite) TestAddAPIVersionToURL(c *gc.C) {
-	apiurl := AddAPIVersionToURL("http://example.com/MAAS", "1.0")
-	expectedURL := "http://example.com/MAAS/api/1.0/"
-	c.Assert(expectedURL, jc.DeepEquals, apiurl)
+	addVersion := AddAPIVersionToURL
+	c.Assert(addVersion("http://example.com/MAAS", "1.0"), gc.Equals, "http://example.com/MAAS/api/1.0/")
+	c.Assert(addVersion("http://example.com/MAAS/", "2.0"), gc.Equals, "http://example.com/MAAS/api/2.0/")
+}
+
+func (suite *ClientSuite) TestSplitVersionedURL(c *gc.C) {
+	check := func(url, expectedBase, expectedVersion string, expectedResult bool) {
+		base, version, ok := splitVersionedURL(url)
+		c.Check(ok, gc.Equals, expectedResult)
+		c.Check(base, gc.Equals, expectedBase)
+		c.Check(version, gc.Equals, expectedVersion)
+	}
+	check("http://maas.server/MAAS", "http://maas.server/MAAS", "", false)
+	check("http://maas.server/MAAS/api/3.0", "http://maas.server/MAAS/", "3.0", true)
+	check("http://maas.server/MAAS/api/3.0/", "http://maas.server/MAAS/", "3.0", true)
+	check("http://maas.server/MAAS/api/maas", "http://maas.server/MAAS/api/maas", "", false)
 }

--- a/errors.go
+++ b/errors.go
@@ -65,6 +65,27 @@ func IsUnsupportedVersionError(err error) bool {
 	return ok
 }
 
+// BadVersionInfoError is more specific than UnsupportedVersionError -
+// it means that we couldn't read the version info endpoint, so the
+// API version is probably wrong. Used in version selection when
+// creating a controller.
+type BadVersionInfoError struct {
+	errors.Err
+}
+
+// NewBadVersionInfoError constructs a new BadVersionInfoError and sets the location.
+func NewBadVersionInfoError(err error) error {
+	uerr := &BadVersionInfoError{Err: errors.NewErr("bad version info: %v", err)}
+	uerr.SetLocation(1)
+	return errors.Wrap(err, uerr)
+}
+
+// IsBadVersionInfoError returns true if err is an BadVersionInfoError.
+func IsBadVersionInfoError(err error) bool {
+	_, ok := errors.Cause(err).(*BadVersionInfoError)
+	return ok
+}
+
 // DeserializationError types are returned when the returned JSON data from
 // the controller doesn't match the code's expectations.
 type DeserializationError struct {

--- a/errors_test.go
+++ b/errors_test.go
@@ -29,6 +29,14 @@ func (*errorTypesSuite) TestUnexpectedError(c *gc.C) {
 	c.Assert(err.Error(), gc.Equals, "unexpected: wat")
 }
 
+func (*errorTypesSuite) TestNewBadVersionInfoError(c *gc.C) {
+	err := errors.New("wat")
+	err = NewBadVersionInfoError(err)
+	c.Assert(err, gc.NotNil)
+	c.Assert(err, jc.Satisfies, IsBadVersionInfoError)
+	c.Assert(err.Error(), gc.Equals, "bad version info: wat")
+}
+
 func (*errorTypesSuite) TestUnsupportedVersionError(c *gc.C) {
 	err := NewUnsupportedVersionError("foo %d", 42)
 	c.Assert(err, gc.NotNil)

--- a/example/live_example.go
+++ b/example/live_example.go
@@ -50,7 +50,8 @@ func main() {
 	getParams()
 
 	// Create API server endpoint.
-	authClient, err := gomaasapi.NewAuthenticatedClient(apiURL, apiKey, apiVersion)
+	authClient, err := gomaasapi.NewAuthenticatedClient(
+		gomaasapi.AddAPIVersionToURL(apiURL, apiVersion), apiKey)
 	checkError(err)
 	maas := gomaasapi.NewMAAS(*authClient)
 


### PR DESCRIPTION
At the moment if someone tries to specify a particular API version in the URL (e.g. `http://maas.server/MAAS/api/2.0/`), we try to tack the version on the end again and fail to connect. Handle this by detecting the version in the URL and skipping the normal loop over supported versions.

Fix for this Juju bug: https://bugs.launchpad.net/juju/+bug/1675485