### PR TITLE
Make SplitVersionedURL public

### DIFF
--- a/client.go
+++ b/client.go
@@ -276,11 +276,12 @@ func AddAPIVersionToURL(BaseURL, apiVersion string) string {
 
 var apiVersionPattern = regexp.MustCompile(`^(?P<base>.*/)api/(?P<version>\d+\.\d+)/?$`)
 
-//splitVersionedURL splits a versioned API URL (like
-//http://maas.server/MAAS/api/2.0/) into a base URL
-//(http://maas.server/MAAS/) and API version (2.0). If the URL doesn't
-//include a version component the bool return value will be false.
-func splitVersionedURL(url string) (string, string, bool) {
+// SplitVersionedURL splits a versioned API URL (like
+// http://maas.server/MAAS/api/2.0/) into a base URL
+// (http://maas.server/MAAS/) and API version (2.0). If the URL
+// doesn't include a version component the bool return value will be
+// false.
+func SplitVersionedURL(url string) (string, string, bool) {
 	if !apiVersionPattern.MatchString(url) {
 		return url, "", false
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -318,7 +318,7 @@ func (suite *ClientSuite) TestAddAPIVersionToURL(c *gc.C) {
 
 func (suite *ClientSuite) TestSplitVersionedURL(c *gc.C) {
 	check := func(url, expectedBase, expectedVersion string, expectedResult bool) {
-		base, version, ok := splitVersionedURL(url)
+		base, version, ok := SplitVersionedURL(url)
 		c.Check(ok, gc.Equals, expectedResult)
 		c.Check(base, gc.Equals, expectedBase)
 		c.Check(version, gc.Equals, expectedVersion)

--- a/controller.go
+++ b/controller.go
@@ -53,7 +53,7 @@ type ControllerArgs struct {
 // If the APIKey is not valid, a NotValid error is returned.
 // If the credentials are incorrect, a PermissionError is returned.
 func NewController(args ControllerArgs) (Controller, error) {
-	base, apiVersion, includesVersion := splitVersionedURL(args.BaseURL)
+	base, apiVersion, includesVersion := SplitVersionedURL(args.BaseURL)
 	if includesVersion {
 		if !supportedVersion(apiVersion) {
 			return nil, NewUnsupportedVersionError("version %s", apiVersion)


### PR DESCRIPTION
It's needed in juju to decide whether we need to add the API version
when falling back to the non-controller interface.