### PR TITLE
Don't return UnsupportedVersionError for unexpected errors from version check

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -65,25 +65,12 @@ func IsUnsupportedVersionError(err error) bool {
 	return ok
 }
 
-// BadVersionInfoError is more specific than UnsupportedVersionError -
-// it means that we couldn't read the version info endpoint, so the
-// API version is probably wrong. Used in version selection when
-// creating a controller.
-type BadVersionInfoError struct {
-	errors.Err
-}
-
-// NewBadVersionInfoError constructs a new BadVersionInfoError and sets the location.
-func NewBadVersionInfoError(err error) error {
-	uerr := &BadVersionInfoError{Err: errors.NewErr("bad version info: %v", err)}
+// WrapWithUnsupportedVersionError constructs a new
+// UnsupportedVersionError wrapping the passed error.
+func WrapWithUnsupportedVersionError(err error) error {
+	uerr := &UnsupportedVersionError{Err: errors.NewErr("unsupported version: %v", err)}
 	uerr.SetLocation(1)
 	return errors.Wrap(err, uerr)
-}
-
-// IsBadVersionInfoError returns true if err is an BadVersionInfoError.
-func IsBadVersionInfoError(err error) bool {
-	_, ok := errors.Cause(err).(*BadVersionInfoError)
-	return ok
 }
 
 // DeserializationError types are returned when the returned JSON data from

--- a/errors_test.go
+++ b/errors_test.go
@@ -29,19 +29,20 @@ func (*errorTypesSuite) TestUnexpectedError(c *gc.C) {
 	c.Assert(err.Error(), gc.Equals, "unexpected: wat")
 }
 
-func (*errorTypesSuite) TestNewBadVersionInfoError(c *gc.C) {
-	err := errors.New("wat")
-	err = NewBadVersionInfoError(err)
-	c.Assert(err, gc.NotNil)
-	c.Assert(err, jc.Satisfies, IsBadVersionInfoError)
-	c.Assert(err.Error(), gc.Equals, "bad version info: wat")
-}
-
 func (*errorTypesSuite) TestUnsupportedVersionError(c *gc.C) {
 	err := NewUnsupportedVersionError("foo %d", 42)
 	c.Assert(err, gc.NotNil)
 	c.Assert(err, jc.Satisfies, IsUnsupportedVersionError)
 	c.Assert(err.Error(), gc.Equals, "foo 42")
+}
+
+func (*errorTypesSuite) TestWrapWithUnsupportedVersionError(c *gc.C) {
+	err := WrapWithUnsupportedVersionError(errors.New("bad"))
+	c.Assert(err, gc.NotNil)
+	c.Assert(err, jc.Satisfies, IsUnsupportedVersionError)
+	c.Assert(err.Error(), gc.Equals, "unsupported version: bad")
+	stack := errors.ErrorStack(err)
+	c.Assert(strings.Split(stack, "\n"), gc.HasLen, 2)
 }
 
 func (*errorTypesSuite) TestDeserializationError(c *gc.C) {


### PR DESCRIPTION
MAAS 2.x and 1.9 will always return 410 (for known but not supported
versions) or 404 (for unknown versions). Only return
UnsupportedVersionError for those codes, let other errors bubble up
unchanged so that we don't confuse network errors for unsupported
versions.

Fixes https://bugs.launchpad.net/juju/+bug/1667095