### PR TITLE
Work around MAAS 1.9.4 bug

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -848,6 +848,13 @@ func indicatesUnsupportedVersion(err error) bool {
 		code := serverErr.StatusCode
 		return code == http.StatusNotFound || code == http.StatusGone
 	}
+	// Workaround for bug in MAAS 1.9.4 - instead of a 404 we get a
+	// redirect to the HTML login page, which doesn't parse as JSON.
+	// https://bugs.launchpad.net/maas/+bug/1583715
+	if syntaxErr, ok := errors.Cause(err).(*json.SyntaxError); ok {
+		message := "invalid character '<' looking for beginning of value"
+		return syntaxErr.Offset == 1 && syntaxErr.Error() == message
+	}
 	return false
 }
 


### PR DESCRIPTION
Handle a JSON deserialisation error caused by the API version requiring
login in MAAS 1.9.4 - this is fixed in 1.9.5, but we shouldn't break
this for 1.9.4 users right now.

This was masked by the old behaviour of treating any error as an 
unsupported version, but now that we're stricter this error becomes apparent.

MAAS bug: https://bugs.launchpad.net/maas/+bug/1583715
Fixes https://bugs.launchpad.net/juju/+bug/1680046