### PR TITLE
Expose block device id_path attribute

### DIFF
--- a/blockdevice.go
+++ b/blockdevice.go
@@ -15,6 +15,7 @@ type blockdevice struct {
 	id      int
 	name    string
 	model   string
+	idPath  string
 	path    string
 	usedFor string
 	tags    []string
@@ -39,6 +40,11 @@ func (b *blockdevice) Name() string {
 // Model implements BlockDevice.
 func (b *blockdevice) Model() string {
 	return b.model
+}
+
+// IDPath implements BlockDevice.
+func (b *blockdevice) IDPath() string {
+	return b.idPath
 }
 
 // Path implements BlockDevice.
@@ -131,6 +137,7 @@ func blockdevice_2_0(source map[string]interface{}) (*blockdevice, error) {
 		"id":       schema.ForceInt(),
 		"name":     schema.String(),
 		"model":    schema.OneOf(schema.Nil(""), schema.String()),
+		"id_path":  schema.OneOf(schema.Nil(""), schema.String()),
 		"path":     schema.String(),
 		"used_for": schema.String(),
 		"tags":     schema.List(schema.String()),
@@ -156,12 +163,14 @@ func blockdevice_2_0(source map[string]interface{}) (*blockdevice, error) {
 	}
 
 	model, _ := valid["model"].(string)
+	idPath, _ := valid["id_path"].(string)
 	result := &blockdevice{
 		resourceURI: valid["resource_uri"].(string),
 
 		id:      valid["id"].(int),
 		name:    valid["name"].(string),
 		model:   model,
+		idPath:  idPath,
 		path:    valid["path"].(string),
 		usedFor: valid["used_for"].(string),
 		tags:    convertToStringSlice(valid["tags"]),

--- a/blockdevice_test.go
+++ b/blockdevice_test.go
@@ -29,6 +29,7 @@ func (*blockdeviceSuite) TestReadBlockDevices(c *gc.C) {
 	c.Check(blockdevice.Name(), gc.Equals, "sda")
 	c.Check(blockdevice.Model(), gc.Equals, "QEMU HARDDISK")
 	c.Check(blockdevice.Path(), gc.Equals, "/dev/disk/by-dname/sda")
+	c.Check(blockdevice.IDPath(), gc.Equals, "/dev/disk/by-id/ata-QEMU_HARDDISK_QM00001")
 	c.Check(blockdevice.UsedFor(), gc.Equals, "MBR partitioned with 1 partition")
 	c.Check(blockdevice.Tags(), jc.DeepEquals, []string{"rotary"})
 	c.Check(blockdevice.BlockSize(), gc.Equals, uint64(4096))
@@ -49,6 +50,7 @@ func (*blockdeviceSuite) TestReadBlockDevicesWithNulls(c *gc.C) {
 	blockdevice := blockdevices[0]
 
 	c.Check(blockdevice.Model(), gc.Equals, "")
+	c.Check(blockdevice.IDPath(), gc.Equals, "")
 }
 
 func (*blockdeviceSuite) TestLowVersion(c *gc.C) {

--- a/interfaces.go
+++ b/interfaces.go
@@ -353,6 +353,7 @@ type BlockDevice interface {
 	ID() int
 	Name() string
 	Model() string
+	IDPath() string
 	Path() string
 	UsedFor() string
 	Tags() []string


### PR DESCRIPTION
id_path is the attribute we should be using
in Juju as a stable path identifier for block
devices. The value for "path", which we have
been using, is not always accurate.