### PR TITLE
Add ability to handle partition match with the machine allocation constraint map response.

### DIFF
--- a/blockdevice.go
+++ b/blockdevice.go
@@ -91,9 +91,6 @@ func (b *blockdevice) Size() uint64 {
 
 // FileSystem implements BlockDevice.
 func (b *blockdevice) FileSystem() FileSystem {
-	if b.filesystem == nil {
-		return nil
-	}
 	return b.filesystem
 }
 
@@ -170,9 +167,7 @@ func blockdevice_2_0(source map[string]interface{}) (*blockdevice, error) {
 		"filesystem": schema.OneOf(schema.Nil(""), schema.StringMap(schema.Any())),
 		"partitions": schema.List(schema.StringMap(schema.Any())),
 	}
-	defaults := schema.Defaults{
-		"uuid": "",
-	}
+	defaults := schema.Defaults{}
 	checker := schema.FieldMap(fields, defaults)
 	coerced, err := checker.Coerce(source, nil)
 	if err != nil {
@@ -183,9 +178,8 @@ func blockdevice_2_0(source map[string]interface{}) (*blockdevice, error) {
 	// contains fields of the right type.
 
 	var filesystem *filesystem
-	if fsSource := valid["filesystem"]; fsSource != nil {
-		filesystem, err = filesystem2_0(fsSource.(map[string]interface{}))
-		if err != nil {
+	if fsSource, ok := valid["filesystem"].(map[string]interface{}); ok {
+		if filesystem, err = filesystem2_0(fsSource); err != nil {
 			return nil, errors.Trace(err)
 		}
 	}

--- a/blockdevice.go
+++ b/blockdevice.go
@@ -167,8 +167,7 @@ func blockdevice_2_0(source map[string]interface{}) (*blockdevice, error) {
 		"filesystem": schema.OneOf(schema.Nil(""), schema.StringMap(schema.Any())),
 		"partitions": schema.List(schema.StringMap(schema.Any())),
 	}
-	defaults := schema.Defaults{}
-	checker := schema.FieldMap(fields, defaults)
+	checker := schema.FieldMap(fields, nil)
 	coerced, err := checker.Coerce(source, nil)
 	if err != nil {
 		return nil, WrapWithDeserializationError(err, "blockdevice 2.0 schema check failed")

--- a/blockdevice_test.go
+++ b/blockdevice_test.go
@@ -57,6 +57,7 @@ func (*blockdeviceSuite) TestReadBlockDevicesWithNulls(c *gc.C) {
 
 	c.Check(blockdevice.Model(), gc.Equals, "")
 	c.Check(blockdevice.IDPath(), gc.Equals, "")
+	c.Check(blockdevice.FileSystem(), gc.IsNil)
 }
 
 func (*blockdeviceSuite) TestLowVersion(c *gc.C) {

--- a/blockdevice_test.go
+++ b/blockdevice_test.go
@@ -30,6 +30,7 @@ func (*blockdeviceSuite) TestReadBlockDevices(c *gc.C) {
 	c.Check(blockdevice.Model(), gc.Equals, "QEMU HARDDISK")
 	c.Check(blockdevice.Path(), gc.Equals, "/dev/disk/by-dname/sda")
 	c.Check(blockdevice.IDPath(), gc.Equals, "/dev/disk/by-id/ata-QEMU_HARDDISK_QM00001")
+	c.Check(blockdevice.UUID(), gc.Equals, "6199b7c9-b66f-40f6-a238-a938a58a0adf")
 	c.Check(blockdevice.UsedFor(), gc.Equals, "MBR partitioned with 1 partition")
 	c.Check(blockdevice.Tags(), jc.DeepEquals, []string{"rotary"})
 	c.Check(blockdevice.BlockSize(), gc.Equals, uint64(4096))
@@ -41,6 +42,11 @@ func (*blockdeviceSuite) TestReadBlockDevices(c *gc.C) {
 	partition := partitions[0]
 	c.Check(partition.ID(), gc.Equals, 1)
 	c.Check(partition.UsedFor(), gc.Equals, "ext4 formatted filesystem mounted at /")
+
+	fs := blockdevice.FileSystem()
+	c.Assert(fs, gc.NotNil)
+	c.Assert(fs.Type(), gc.Equals, "ext4")
+	c.Assert(fs.MountPoint(), gc.Equals, "/srv")
 }
 
 func (*blockdeviceSuite) TestReadBlockDevicesWithNulls(c *gc.C) {
@@ -89,7 +95,13 @@ var blockdevicesResponse = `
                 "size": 8581545984
             }
         ],
-        "filesystem": null,
+        "filesystem": {
+            "fstype": "ext4",
+            "mount_point": "/srv",
+            "label": "root",
+            "mount_options": null,
+            "uuid": "fcd7745e-f1b5-4f5d-9575-9b0bb796b752"
+        },
         "id_path": "/dev/disk/by-id/ata-QEMU_HARDDISK_QM00001",
         "resource_uri": "/MAAS/api/2.0/nodes/4y3ha3/blockdevices/34/",
         "id": 34,
@@ -99,7 +111,7 @@ var blockdevicesResponse = `
         "used_size": 8586788864,
         "available_size": 0,
         "partition_table_type": "MBR",
-        "uuid": null,
+        "uuid": "6199b7c9-b66f-40f6-a238-a938a58a0adf",
         "size": 8589934592,
         "model": "QEMU HARDDISK",
         "tags": [

--- a/controller.go
+++ b/controller.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 	"sync/atomic"
 
@@ -530,9 +531,9 @@ type ConstraintMatches struct {
 	// that match that constraint.
 	Interfaces map[string][]Interface
 
-	// Storage is a mapping of the constraint label specified to the BlockDevices
+	// Storage is a mapping of the constraint label specified to the StorageDevice
 	// that match that constraint.
-	Storage map[string][]BlockDevice
+	Storage map[string][]StorageDevice
 }
 
 // AllocateMachine implements Controller.
@@ -912,7 +913,7 @@ func (c *controller) readAPIVersionInfo() (set.Strings, error) {
 func parseAllocateConstraintsResponse(source interface{}, machine *machine) (ConstraintMatches, error) {
 	var empty ConstraintMatches
 	matchFields := schema.Fields{
-		"storage":    schema.StringMap(schema.List(schema.ForceInt())),
+		"storage":    schema.StringMap(schema.List(schema.Any())),
 		"interfaces": schema.StringMap(schema.List(schema.ForceInt())),
 	}
 	matchDefaults := schema.Defaults{
@@ -931,7 +932,7 @@ func parseAllocateConstraintsResponse(source interface{}, machine *machine) (Con
 	constraintsMap := valid["constraints_by_type"].(map[string]interface{})
 	result := ConstraintMatches{
 		Interfaces: make(map[string][]Interface),
-		Storage:    make(map[string][]BlockDevice),
+		Storage:    make(map[string][]StorageDevice),
 	}
 
 	if interfaceMatches, found := constraintsMap["interfaces"]; found {
@@ -939,7 +940,7 @@ func parseAllocateConstraintsResponse(source interface{}, machine *machine) (Con
 		for label, ids := range matches {
 			interfaces := make([]Interface, len(ids))
 			for index, id := range ids {
-				iface := machine.Interface(id)
+				iface := machine.Interface(id.(int))
 				if iface == nil {
 					return empty, NewDeserializationError("constraint match interface %q: %d does not match an interface for the machine", label, id)
 				}
@@ -952,29 +953,50 @@ func parseAllocateConstraintsResponse(source interface{}, machine *machine) (Con
 	if storageMatches, found := constraintsMap["storage"]; found {
 		matches := convertConstraintMatches(storageMatches)
 		for label, ids := range matches {
-			blockDevices := make([]BlockDevice, len(ids))
-			for index, id := range ids {
-				blockDevice := machine.BlockDevice(id)
-				if blockDevice == nil {
-					return empty, NewDeserializationError("constraint match storage %q: %d does not match a block device for the machine", label, id)
+			storageDevices := make([]StorageDevice, len(ids))
+			for index, storageId := range ids {
+				if id, ok := storageId.(float64); ok {
+					// Links to a block device.
+					blockDevice := machine.BlockDevice(int(id))
+					if blockDevice == nil {
+						return empty, NewDeserializationError("constraint match storage %q: %d does not match a block device for the machine", label, int(id))
+					}
+					storageDevices[index] = blockDevice
+				} else if id, ok := storageId.(string); ok {
+					// Should link to a partition.
+					const partPrefix = "partition:"
+					if strings.HasPrefix(id, partPrefix) {
+						partId, err := strconv.Atoi(id[len(partPrefix):])
+						if err != nil {
+							return empty, NewDeserializationError("constraint match storage %q: %s cannot convert to int.", label, id[len(partPrefix):])
+						}
+						partition := machine.Partition(partId)
+						if partition == nil {
+							return empty, NewDeserializationError("constraint match storage %q: %d does not match a partition for the machine", label, partId)
+						}
+						storageDevices[index] = partition
+					} else {
+						return empty, NewDeserializationError("constraint match storage %q: %s is not prefixed with partition", label, id)
+					}
+				} else {
+					return empty, NewDeserializationError("constraint match storage %q: %v is not an int or string", label, storageId)
 				}
-				blockDevices[index] = blockDevice
 			}
-			result.Storage[label] = blockDevices
+			result.Storage[label] = storageDevices
 		}
 	}
 	return result, nil
 }
 
-func convertConstraintMatches(source interface{}) map[string][]int {
+func convertConstraintMatches(source interface{}) map[string][]interface{} {
 	// These casts are all safe because of the schema check.
-	result := make(map[string][]int)
+	result := make(map[string][]interface{})
 	matchMap := source.(map[string]interface{})
 	for label, values := range matchMap {
 		items := values.([]interface{})
-		result[label] = make([]int, len(items))
+		result[label] = make([]interface{}, len(items))
 		for index, value := range items {
-			result[label][index] = value.(int)
+			result[label][index] = value
 		}
 	}
 	return result

--- a/controller_test.go
+++ b/controller_test.go
@@ -644,15 +644,23 @@ func (s *controllerSuite) TestAllocateMachineStorageLogicalMatches(c *gc.C) {
 	s.server.AddPostResponse("/api/2.0/machines/?op=allocate", http.StatusOK, machineResponse)
 	controller := s.getController(c)
 	machine, matches, err := controller.AllocateMachine(AllocateMachineArgs{
-		Storage: []StorageSpec{{
-			Tags: []string{"raid0"},
-		}},
+		Storage: []StorageSpec{
+			{
+				Tags: []string{"raid0"},
+			},
+			{
+				Tags: []string{"partition"},
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	var virtualDeviceID = 23
+	var partitionID = 1
 
 	//matches storage must contain the "raid0" virtual block device
 	c.Assert(matches.Storage["0"][0], gc.Equals, machine.BlockDevice(virtualDeviceID))
+	//matches storage must contain the partition from physical block device
+	c.Assert(matches.Storage["1"][0], gc.Equals, machine.Partition(partitionID))
 }
 
 func (s *controllerSuite) TestAllocateMachineStorageMatchMissing(c *gc.C) {

--- a/domain.go
+++ b/domain.go
@@ -37,10 +37,10 @@ func domain_(source map[string]interface{}) (*domain, error) {
 	fields := schema.Fields{
 		"authoritative":         schema.Bool(),
 		"resource_record_count": schema.ForceInt(),
-		"ttl":          schema.OneOf(schema.Nil("null"), schema.ForceInt()),
-		"resource_uri": schema.String(),
-		"id":           schema.ForceInt(),
-		"name":         schema.String(),
+		"ttl":                   schema.OneOf(schema.Nil("null"), schema.ForceInt()),
+		"resource_uri":          schema.String(),
+		"id":                    schema.ForceInt(),
+		"name":                  schema.String(),
 	}
 	checker := schema.FieldMap(fields, nil) // no defaults
 	coerced, err := checker.Coerce(source, nil)

--- a/interfaces.go
+++ b/interfaces.go
@@ -234,6 +234,7 @@ type Machine interface {
 	// BlockDevice returns the block device for the machine that matches the
 	// id specified. If there is no match, nil is returned.
 	BlockDevice(id int) BlockDevice
+
 	// Partition returns the partition for the machine that matches the
 	// id specified. If there is no match, nil is returned.
 	Partition(id int) Partition

--- a/interfaces.go
+++ b/interfaces.go
@@ -234,6 +234,9 @@ type Machine interface {
 	// BlockDevice returns the block device for the machine that matches the
 	// id specified. If there is no match, nil is returned.
 	BlockDevice(id int) BlockDevice
+	// Partition returns the partition for the machine that matches the
+	// id specified. If there is no match, nil is returned.
+	Partition(id int) Partition
 
 	Zone() Zone
 
@@ -345,33 +348,41 @@ type FileSystem interface {
 	UUID() string
 }
 
+// StorageDevice represents any piece of storage on a machine. Partition
+// and BlockDevice are storage devices.
+type StorageDevice interface {
+	// Type is the type of item.
+	Type() string
+
+	// ID is the unique ID of the item of that type.
+	ID() int
+
+	Path() string
+	UsedFor() string
+	Size() uint64
+	UUID() string
+	Tags() []string
+
+	// FileSystem may be nil if not mounted.
+	FileSystem() FileSystem
+}
+
 // Partition represents a partition of a block device. It may be mounted
 // as a filesystem.
 type Partition interface {
-	ID() int
-	Path() string
-	// FileSystem may be nil if not mounted.
-	FileSystem() FileSystem
-	UUID() string
-	// UsedFor is a human readable string.
-	UsedFor() string
-	// Size is the number of bytes in the partition.
-	Size() uint64
+	StorageDevice
 }
 
 // BlockDevice represents an entire block device on the machine.
 type BlockDevice interface {
-	ID() int
+	StorageDevice
+
 	Name() string
 	Model() string
 	IDPath() string
-	Path() string
-	UsedFor() string
-	Tags() []string
 
 	BlockSize() uint64
 	UsedSize() uint64
-	Size() uint64
 
 	Partitions() []Partition
 

--- a/machine.go
+++ b/machine.go
@@ -204,6 +204,22 @@ func blockDeviceById(id int, blockDevices []BlockDevice) BlockDevice {
 	return nil
 }
 
+// Partition implements Machine.
+func (m *machine) Partition(id int) Partition {
+	return partitionById(id, m.BlockDevices())
+}
+
+func partitionById(id int, blockDevices []BlockDevice) Partition {
+	for _, blockDevice := range blockDevices {
+		for _, partition := range blockDevice.Partitions() {
+			if partition.ID() == id {
+				return partition
+			}
+		}
+	}
+	return nil
+}
+
 // Devices implements Machine.
 func (m *machine) Devices(args DevicesArgs) ([]Device, error) {
 	// Perhaps in the future, MAAS will give us a way to query just for the

--- a/machine_test.go
+++ b/machine_test.go
@@ -425,6 +425,9 @@ const (
           "storage": {
               "0": [
                   23
+              ],
+              "1": [
+                  "partition:1"
               ]
           }
          },

--- a/partition.go
+++ b/partition.go
@@ -123,7 +123,6 @@ func partition_2_0(source map[string]interface{}) (*partition, error) {
 		"filesystem": schema.OneOf(schema.Nil(""), schema.StringMap(schema.Any())),
 	}
 	defaults := schema.Defaults{
-		"uuid": "",
 		"tags": []string{},
 	}
 	checker := schema.FieldMap(fields, defaults)
@@ -136,12 +135,12 @@ func partition_2_0(source map[string]interface{}) (*partition, error) {
 	// contains fields of the right type.
 
 	var filesystem *filesystem
-	if fsSource := valid["filesystem"]; fsSource != nil {
-		filesystem, err = filesystem2_0(fsSource.(map[string]interface{}))
-		if err != nil {
+	if fsSource, ok := valid["filesystem"].(map[string]interface{}); ok {
+		if filesystem, err = filesystem2_0(fsSource); err != nil {
 			return nil, errors.Trace(err)
 		}
 	}
+
 	uuid, _ := valid["uuid"].(string)
 	result := &partition{
 		resourceURI: valid["resource_uri"].(string),

--- a/partition.go
+++ b/partition.go
@@ -12,14 +12,19 @@ import (
 type partition struct {
 	resourceURI string
 
-	id   int
-	path string
-	uuid string
-
+	id      int
+	path    string
+	uuid    string
 	usedFor string
 	size    uint64
+	tags    []string
 
 	filesystem *filesystem
+}
+
+// Type implements Partition.
+func (p *partition) Type() string {
+	return "partition"
 }
 
 // ID implements Partition.
@@ -53,6 +58,11 @@ func (p *partition) UsedFor() string {
 // Size implements Partition.
 func (p *partition) Size() uint64 {
 	return p.size
+}
+
+// Tags implements Partition.
+func (p *partition) Tags() []string {
+	return p.tags
 }
 
 func readPartitions(controllerVersion version.Number, source interface{}) ([]*partition, error) {
@@ -103,17 +113,18 @@ func partition_2_0(source map[string]interface{}) (*partition, error) {
 	fields := schema.Fields{
 		"resource_uri": schema.String(),
 
-		"id":   schema.ForceInt(),
-		"path": schema.String(),
-		"uuid": schema.OneOf(schema.Nil(""), schema.String()),
-
+		"id":       schema.ForceInt(),
+		"path":     schema.String(),
+		"uuid":     schema.OneOf(schema.Nil(""), schema.String()),
 		"used_for": schema.String(),
 		"size":     schema.ForceUint(),
+		"tags":     schema.List(schema.String()),
 
 		"filesystem": schema.OneOf(schema.Nil(""), schema.StringMap(schema.Any())),
 	}
 	defaults := schema.Defaults{
 		"uuid": "",
+		"tags": []string{},
 	}
 	checker := schema.FieldMap(fields, defaults)
 	coerced, err := checker.Coerce(source, nil)
@@ -134,12 +145,15 @@ func partition_2_0(source map[string]interface{}) (*partition, error) {
 	uuid, _ := valid["uuid"].(string)
 	result := &partition{
 		resourceURI: valid["resource_uri"].(string),
-		id:          valid["id"].(int),
-		path:        valid["path"].(string),
-		uuid:        uuid,
-		usedFor:     valid["used_for"].(string),
-		size:        valid["size"].(uint64),
-		filesystem:  filesystem,
+
+		id:      valid["id"].(int),
+		path:    valid["path"].(string),
+		uuid:    uuid,
+		usedFor: valid["used_for"].(string),
+		size:    valid["size"].(uint64),
+		tags:    convertToStringSlice(valid["tags"]),
+
+		filesystem: filesystem,
 	}
 	return result, nil
 }

--- a/partition_test.go
+++ b/partition_test.go
@@ -13,6 +13,11 @@ type partitionSuite struct{}
 
 var _ = gc.Suite(&partitionSuite{})
 
+func (*partitionSuite) TestTypePartition(c *gc.C) {
+	var empty partition
+	c.Assert(empty.Type() == "partition", jc.IsTrue)
+}
+
 func (*partitionSuite) TestNilFileSystem(c *gc.C) {
 	var empty partition
 	c.Assert(empty.FileSystem() == nil, jc.IsTrue)
@@ -30,11 +35,13 @@ func (*partitionSuite) TestReadPartitions(c *gc.C) {
 	c.Assert(partitions, gc.HasLen, 1)
 	partition := partitions[0]
 
+	c.Check(partition.Type(), gc.Equals, "partition")
 	c.Check(partition.ID(), gc.Equals, 1)
 	c.Check(partition.Path(), gc.Equals, "/dev/disk/by-dname/sda-part1")
 	c.Check(partition.UUID(), gc.Equals, "6199b7c9-b66f-40f6-a238-a938a58a0adf")
 	c.Check(partition.UsedFor(), gc.Equals, "ext4 formatted filesystem mounted at /")
 	c.Check(partition.Size(), gc.Equals, uint64(8581545984))
+	c.Check(partition.Tags(), gc.DeepEquals, []string{"ssd-part", "osd-part"})
 
 	fs := partition.FileSystem()
 	c.Assert(fs, gc.NotNil)
@@ -80,7 +87,8 @@ var partitionsResponse = `
         "resource_uri": "/MAAS/api/2.0/nodes/4y3ha3/blockdevices/34/partition/1",
         "uuid": "6199b7c9-b66f-40f6-a238-a938a58a0adf",
         "used_for": "ext4 formatted filesystem mounted at /",
-        "size": 8581545984
+		"size": 8581545984,
+		"tags": ["ssd-part", "osd-part"]
     }
 ]
 `


### PR DESCRIPTION
MAAS 2.5 has added the ability for tags to match a partition and not just a block device when performing allocation with storage constraints.

This change allows this to on MAAS 2.5, while also not breaking versions before. This adds a new interface `StorageDevice` that can be either a partition or a block device.