### PR TITLE
Allow devices without pools to be properly parsed

### DIFF
--- a/device.go
+++ b/device.go
@@ -261,7 +261,7 @@ func device_2_0(source map[string]interface{}) (*device, error) {
 		"ip_addresses":  schema.List(schema.String()),
 		"interface_set": schema.List(schema.StringMap(schema.Any())),
 		"zone":          schema.StringMap(schema.Any()),
-		"pool":          schema.StringMap(schema.Any()),
+		"pool":          schema.OneOf(schema.Nil(""), schema.StringMap(schema.Any())),
 	}
 	defaults := schema.Defaults{
 		"owner":  "",
@@ -286,11 +286,13 @@ func device_2_0(source map[string]interface{}) (*device, error) {
 		return nil, errors.Trace(err)
 	}
 
-	pool, err := pool_2_0(valid["pool"].(map[string]interface{}))
-
-	if err != nil {
-		return nil, errors.Trace(err)
+	var pool *pool
+	if valid["pool"] != nil {
+		if pool, err = pool_2_0(valid["pool"].(map[string]interface{})); err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
+
 	owner, _ := valid["owner"].(string)
 	parent, _ := valid["parent"].(string)
 	result := &device{

--- a/device_test.go
+++ b/device_test.go
@@ -43,6 +43,9 @@ func (*deviceSuite) TestReadDevices(c *gc.C) {
 	zone := device.Zone()
 	c.Check(zone, gc.NotNil)
 	c.Check(zone.Name(), gc.Equals, "default")
+	pool := device.Pool()
+	c.Check(pool, gc.NotNil)
+	c.Check(pool.Name(), gc.Equals, "default")
 }
 
 func (*deviceSuite) TestReadDevicesNils(c *gc.C) {
@@ -50,6 +53,7 @@ func (*deviceSuite) TestReadDevicesNils(c *gc.C) {
 	deviceMap := json.([]interface{})[0].(map[string]interface{})
 	deviceMap["owner"] = nil
 	deviceMap["parent"] = nil
+	deviceMap["pool"] = nil
 	devices, err := readDevices(twoDotOh, json)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(devices, gc.HasLen, 1)
@@ -57,6 +61,7 @@ func (*deviceSuite) TestReadDevicesNils(c *gc.C) {
 	device := devices[0]
 	c.Check(device.Owner(), gc.Equals, "")
 	c.Check(device.Parent(), gc.Equals, "")
+	c.Check(device.Pool(), gc.IsNil)
 }
 
 func (*deviceSuite) TestLowVersion(c *gc.C) {
@@ -234,7 +239,7 @@ const (
             "resource_uri": "/MAAS/api/2.0/zones/default/",
             "name": "default"
         },
-		"pool": {
+        "pool": {
             "description": "",
             "resource_uri": "/MAAS/api/2.0/pools/default/",
             "name": "default"

--- a/testservice_test.go
+++ b/testservice_test.go
@@ -2039,7 +2039,6 @@ func (suite *TestMAASObjectSuite) TestAcquireFilterTag(c *C) {
 	c.Assert(err, IsNil)
 	acquiredNode, err := jsonResponse.GetMAASObject()
 	c.Assert(err, IsNil)
-	fmt.Printf("%v\n", acquiredNode)
 	tag, _ := acquiredNode.GetField("tag_names")
 	c.Assert(tag, Equals, "GPU")
 }


### PR DESCRIPTION
Based on #80 by @stgraber

Allow device responses which do not specify a pool.