### PR TITLE
Allow machines without pools to be properly parsed.

### DIFF
--- a/machine.go
+++ b/machine.go
@@ -520,7 +520,7 @@ func machine_2_0(source map[string]interface{}) (*machine, error) {
 		"boot_interface": schema.OneOf(schema.Nil(""), schema.StringMap(schema.Any())),
 		"interface_set":  schema.List(schema.StringMap(schema.Any())),
 		"zone":           schema.StringMap(schema.Any()),
-		"pool":           schema.StringMap(schema.Any()),
+		"pool":           schema.OneOf(schema.Nil(""), schema.Any()),
 
 		"physicalblockdevice_set": schema.List(schema.StringMap(schema.Any())),
 		"blockdevice_set":         schema.List(schema.StringMap(schema.Any())),
@@ -556,10 +556,11 @@ func machine_2_0(source map[string]interface{}) (*machine, error) {
 		return nil, errors.Trace(err)
 	}
 
-	pool, err := pool_2_0(valid["pool"].(map[string]interface{}))
-	if err != nil {
-
-		return nil, errors.Trace(err)
+	var pool *pool
+	if valid["pool"] != nil {
+		if pool, err = pool_2_0(valid["pool"].(map[string]interface{})); err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 
 	physicalBlockDevices, err := readBlockDeviceList(valid["physicalblockdevice_set"].([]interface{}), blockdevice_2_0)

--- a/machine_test.go
+++ b/machine_test.go
@@ -94,6 +94,10 @@ func (*machineSuite) TestReadMachines(c *gc.C) {
 	id = blockDevices[0].ID()
 	c.Assert(machine.PhysicalBlockDevice(id), jc.DeepEquals, blockDevices[0])
 	c.Assert(machine.PhysicalBlockDevice(id+5), gc.IsNil)
+
+	pool := machine.Pool()
+	c.Check(pool, gc.NotNil)
+	c.Check(pool.Name(), gc.Equals, "default")
 }
 
 func (*machineSuite) TestReadMachinesNilValues(c *gc.C) {
@@ -102,6 +106,7 @@ func (*machineSuite) TestReadMachinesNilValues(c *gc.C) {
 	data["architecture"] = nil
 	data["status_message"] = nil
 	data["boot_interface"] = nil
+	data["pool"] = nil
 	machines, err := readMachines(twoDotOh, json)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.HasLen, 3)
@@ -109,6 +114,7 @@ func (*machineSuite) TestReadMachinesNilValues(c *gc.C) {
 	c.Check(machine.Architecture(), gc.Equals, "")
 	c.Check(machine.StatusMessage(), gc.Equals, "")
 	c.Check(machine.BootInterface(), gc.IsNil)
+	c.Check(machine.Pool(), gc.IsNil)
 }
 
 func (*machineSuite) TestLowVersion(c *gc.C) {

--- a/pool.go
+++ b/pool.go
@@ -80,7 +80,7 @@ var poolDeserializationFuncs = map[version.Number]poolDeserializationFunc{
 }
 
 func pool_2_0(source map[string]interface{}) (*pool, error) {
-	fields := schema.Fields {
+	fields := schema.Fields{
 		"name":         schema.String(),
 		"description":  schema.String(),
 		"resource_uri": schema.String(),
@@ -103,4 +103,3 @@ func pool_2_0(source map[string]interface{}) (*pool, error) {
 	}
 	return result, nil
 }
-

--- a/pool_test.go
+++ b/pool_test.go
@@ -57,4 +57,3 @@ var poolResponse = `
     }
 ]
 `
-


### PR DESCRIPTION

Allow machines without pools to be properly parsed. Make changes for machines, as done for devices in #81 .