### PR TITLE
Add all enums

### DIFF
--- a/enum.go
+++ b/enum.go
@@ -54,4 +54,25 @@ const (
 
 	// The node failed to erase its disks.
 	NodeStatusFailedDiskErasing = "15"
+
+	// The node is in rescue mode.
+	NodeStatusRescueMode = "16"
+
+	// The node is entering rescue mode.
+	NodeStatusEnteringRescueMode = "17"
+
+	// The node failed to enter rescue mode.
+	NodeStatusFailedEnteringRescueMode = "18"
+
+	// The node is exiting rescue mode.
+	NodeStatusExitingRescueMode = "19"
+
+	// The node failed to exit rescue mode.
+	NodeStatusFailedExitingRescueMode = "20"
+
+	// Running tests on Node
+	NodeStatusTesting = "21"
+
+	// Testing has failed
+	NodeStatusFailedTesting = "22"
 )


### PR DESCRIPTION
This PR adds some additional machine state enums to `enum.go` that exist in more recent versions of the API.