### PR TITLE
Implement machine.Status() method

### DIFF
--- a/enum.go
+++ b/enum.go
@@ -7,51 +7,51 @@ const (
 	// NodeStatus* values represent the vocabulary of a Node‘s possible statuses.
 
 	// The node has been created and has a system ID assigned to it.
-	NodeStatusDeclared = "0"
+	NodeStatusDeclared = 0
 
 	//Testing and other commissioning steps are taking place.
-	NodeStatusCommissioning = "1"
+	NodeStatusCommissioning = 1
 
 	// Smoke or burn-in testing has a found a problem.
-	NodeStatusFailedTests = "2"
+	NodeStatusFailedTests = 2
 
 	// The node can’t be contacted.
-	NodeStatusMissing = "3"
+	NodeStatusMissing = 3
 
 	// The node is in the general pool ready to be deployed.
-	NodeStatusReady = "4"
+	NodeStatusReady = 4
 
 	// The node is ready for named deployment.
-	NodeStatusReserved = "5"
+	NodeStatusReserved = 5
 
 	// The node is powering a service from a charm or is ready for use with a fresh Ubuntu install.
-	NodeStatusDeployed = "6"
+	NodeStatusDeployed = 6
 
 	// The node has been removed from service manually until an admin overrides the retirement.
-	NodeStatusRetired = "7"
+	NodeStatusRetired = 7
 
 	// The node is broken: a step in the node lifecyle failed. More details
 	// can be found in the node's event log.
-	NodeStatusBroken = "8"
+	NodeStatusBroken = 8
 
 	// The node is being installed.
-	NodeStatusDeploying = "9"
+	NodeStatusDeploying = 9
 
 	// The node has been allocated to a user and is ready for deployment.
-	NodeStatusAllocated = "10"
+	NodeStatusAllocated = 10
 
 	// The deployment of the node failed.
-	NodeStatusFailedDeployment = "11"
+	NodeStatusFailedDeployment = 11
 
 	// The node is powering down after a release request.
-	NodeStatusReleasing = "12"
+	NodeStatusReleasing = 12
 
 	// The releasing of the node failed.
-	NodeStatusFailedReleasing = "13"
+	NodeStatusFailedReleasing = 13
 
 	// The node is erasing its disks.
-	NodeStatusDiskErasing = "14"
+	NodeStatusDiskErasing = 14
 
 	// The node failed to erase its disks.
-	NodeStatusFailedDiskErasing = "15"
+	NodeStatusFailedDiskErasing = 15
 )

--- a/jsonobject.go
+++ b/jsonobject.go
@@ -59,7 +59,7 @@ func maasify(client Client, value interface{}) JSONObject {
 		return JSONObject{isNull: true}
 	}
 	switch value.(type) {
-	case string, float64, bool:
+	case string, float64, bool, int:
 		return JSONObject{value: value}
 	case map[string]interface{}:
 		original := value.(map[string]interface{})

--- a/machine.go
+++ b/machine.go
@@ -34,6 +34,7 @@ type machine struct {
 	powerState  string
 
 	// NOTE: consider some form of status struct
+	status        int
 	statusName    string
 	statusMessage string
 
@@ -165,6 +166,11 @@ func (m *machine) DistroSeries() string {
 // Architecture implements Machine.
 func (m *machine) Architecture() string {
 	return m.architecture
+}
+
+// Status implements Machine.
+func (m *machine) Status() int {
+	return m.status
 }
 
 // StatusName implements Machine.
@@ -516,6 +522,7 @@ func machine_2_0(source map[string]interface{}) (*machine, error) {
 
 		"ip_addresses":   schema.List(schema.String()),
 		"power_state":    schema.String(),
+		"status":         schema.ForceInt(),
 		"status_name":    schema.String(),
 		"status_message": schema.OneOf(schema.Nil(""), schema.String()),
 
@@ -593,6 +600,7 @@ func machine_2_0(source map[string]interface{}) (*machine, error) {
 
 		ipAddresses:   convertToStringSlice(valid["ip_addresses"]),
 		powerState:    valid["power_state"].(string),
+		status:        valid["status"].(int),
 		statusName:    valid["status_name"].(string),
 		statusMessage: statusMessage,
 

--- a/machine_test.go
+++ b/machine_test.go
@@ -67,6 +67,7 @@ func (*machineSuite) TestReadMachines(c *gc.C) {
 	c.Check(machine.OperatingSystem(), gc.Equals, "ubuntu")
 	c.Check(machine.DistroSeries(), gc.Equals, "trusty")
 	c.Check(machine.Architecture(), gc.Equals, "amd64/generic")
+	c.Check(machine.Status(), gc.Equals, NodeStatusDeployed)
 	c.Check(machine.StatusName(), gc.Equals, "Deployed")
 	c.Check(machine.StatusMessage(), gc.Equals, "From 'Deploying' to 'Deployed'")
 

--- a/testservice.go
+++ b/testservice.go
@@ -1027,7 +1027,8 @@ func nodeDeploymentStatusHandler(server *TestServer, w http.ResponseWriter, r *h
 		if err != nil {
 			continue
 		}
-		switch field {
+		status, _ := strconv.Atoi(field)
+		switch status {
 		case NodeStatusDeployed:
 			nodeStatus[systemId] = "Deployed"
 		case NodeStatusFailedDeployment:


### PR DESCRIPTION
`machine.Status()` method returns the status number of machine as string.

I want to use `NodeStatus*` constant in `enum.go` to check the status of the machine. So I'll add `machine.Status()` method.