### PR TITLE
Use v1 suffix for imports and module name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,4 +9,4 @@ API in Go programs.
 
 For more information see the `project homepage`_.
 
-.. _project homepage: https://github.com/juju/gomaasapi
+.. _project homepage: https://github.com/juju/gomaasapi/v1

--- a/example/live_example.go
+++ b/example/live_example.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/juju/gomaasapi"
+	"github.com/juju/gomaasapi/v1"
 )
 
 var apiKey string

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/juju/gomaasapi
+module github.com/juju/gomaasapi/v1
 
 go 1.16
 

--- a/urlparams_test.go
+++ b/urlparams_test.go
@@ -4,7 +4,7 @@
 package gomaasapi_test
 
 import (
-	"github.com/juju/gomaasapi"
+	"github.com/juju/gomaasapi/v1"
 	gc "gopkg.in/check.v1"
 )
 


### PR DESCRIPTION
This PR tidies up the loose ends left by #88.