### PR TITLE
Add "disk erase" support for ReleaseMachines

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -617,8 +617,11 @@ func (c *controller) AllocateMachine(args AllocateMachineArgs) (Machine, Constra
 // ReleaseMachinesArgs is an argument struct for passing the machine system IDs
 // and an optional comment into the ReleaseMachines method.
 type ReleaseMachinesArgs struct {
-	SystemIDs []string
-	Comment   string
+	SystemIDs   []string
+	Comment     string
+	Erase       bool
+	SecureErase bool
+	QuickErase  bool
 }
 
 // ReleaseMachines implements Controller.
@@ -631,6 +634,9 @@ func (c *controller) ReleaseMachines(args ReleaseMachinesArgs) error {
 	params := NewURLParams()
 	params.MaybeAddMany("machines", args.SystemIDs)
 	params.MaybeAdd("comment", args.Comment)
+	params.MaybeAddBool("erase", args.Erase)
+	params.MaybeAddBool("secure_erase", args.SecureErase)
+	params.MaybeAddBool("quick_erase", args.QuickErase)
 	_, err := c.post("machines", "release", params.Values)
 	if err != nil {
 		if svrErr, ok := errors.Cause(err).(ServerError); ok {

--- a/controller_test.go
+++ b/controller_test.go
@@ -742,8 +742,11 @@ func (s *controllerSuite) TestReleaseMachines(c *gc.C) {
 	s.server.AddPostResponse("/api/2.0/machines/?op=release", http.StatusOK, "[]")
 	controller := s.getController(c)
 	err := controller.ReleaseMachines(ReleaseMachinesArgs{
-		SystemIDs: []string{"this", "that"},
-		Comment:   "all good",
+		SystemIDs:   []string{"this", "that"},
+		Comment:     "all good",
+		Erase:       true,
+		SecureErase: true,
+		QuickErase:  true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -751,6 +754,9 @@ func (s *controllerSuite) TestReleaseMachines(c *gc.C) {
 	// There should be one entry in the form values for each of the args.
 	c.Assert(request.PostForm["machines"], jc.SameContents, []string{"this", "that"})
 	c.Assert(request.PostForm.Get("comment"), gc.Equals, "all good")
+	c.Assert(request.PostForm.Get("erase"), gc.Equals, "true")
+	c.Assert(request.PostForm.Get("secure_erase"), gc.Equals, "true")
+	c.Assert(request.PostForm.Get("quick_erase"), gc.Equals, "true")
 }
 
 func (s *controllerSuite) TestReleaseMachinesBadRequest(c *gc.C) {


### PR DESCRIPTION
This PR adds "disk erase" support for ReleaseMachines.