### PR TITLE
Allow configuration of underlying HTTP client.

### DIFF
--- a/client.go
+++ b/client.go
@@ -31,8 +31,9 @@ const (
 // Client represents a way to communicating with a MAAS API instance.
 // It is stateless, so it can have concurrent requests in progress.
 type Client struct {
-	APIURL *url.URL
-	Signer OAuthSigner
+	APIURL     *url.URL
+	Signer     OAuthSigner
+	HTTPClient *http.Client
 }
 
 // ServerError is an http error (or at least, a non-2xx result) received from
@@ -106,7 +107,11 @@ func (client Client) dispatchRequest(request *http.Request) ([]byte, error) {
 
 func (client Client) dispatchSingleRequest(request *http.Request) ([]byte, error) {
 	client.Signer.OAuthSign(request)
-	httpClient := http.Client{}
+	httpClient := &http.Client{}
+	if client.HTTPClient != nil {
+		httpClient = client.HTTPClient
+	}
+
 	// See https://code.google.com/p/go/issues/detail?id=4677
 	// We need to force the connection to close each time so that we don't
 	// hit the above Go bug.

--- a/client_test.go
+++ b/client_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -38,7 +39,7 @@ func (*ClientSuite) TestReadAndCloseReturnsContents(c *gc.C) {
 func (suite *ClientSuite) TestClientdispatchRequestReturnsServerError(c *gc.C) {
 	URI := "/some/url/?param1=test"
 	expectedResult := "expected:result"
-	server := newSingleServingServer(URI, expectedResult, http.StatusBadRequest)
+	server := newSingleServingServer(URI, expectedResult, http.StatusBadRequest, -1)
 	defer server.Close()
 	client, err := NewAnonymousClient(server.URL, "1.0")
 	c.Assert(err, jc.ErrorIsNil)
@@ -126,7 +127,7 @@ func (suite *ClientSuite) TestClientDispatchRequestReturnsNonServerError(c *gc.C
 func (suite *ClientSuite) TestClientdispatchRequestSignsRequest(c *gc.C) {
 	URI := "/some/url/?param1=test"
 	expectedResult := "expected:result"
-	server := newSingleServingServer(URI, expectedResult, http.StatusOK)
+	server := newSingleServingServer(URI, expectedResult, http.StatusOK, -1)
 	defer server.Close()
 	client, err := NewAuthenticatedClient(server.URL, "the:api:key")
 	c.Assert(err, jc.ErrorIsNil)
@@ -146,7 +147,7 @@ func (suite *ClientSuite) TestClientGetFormatsGetParameters(c *gc.C) {
 	expectedResult := "expected:result"
 	params := url.Values{"test": {"123"}}
 	fullURI := URI.String() + "?test=123"
-	server := newSingleServingServer(fullURI, expectedResult, http.StatusOK)
+	server := newSingleServingServer(fullURI, expectedResult, http.StatusOK, -1)
 	defer server.Close()
 	client, err := NewAnonymousClient(server.URL, "1.0")
 	c.Assert(err, jc.ErrorIsNil)
@@ -162,7 +163,7 @@ func (suite *ClientSuite) TestClientGetFormatsOperationAsGetParameter(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := "expected:result"
 	fullURI := URI.String() + "?op=list"
-	server := newSingleServingServer(fullURI, expectedResult, http.StatusOK)
+	server := newSingleServingServer(fullURI, expectedResult, http.StatusOK, -1)
 	defer server.Close()
 	client, err := NewAnonymousClient(server.URL, "1.0")
 	c.Assert(err, jc.ErrorIsNil)
@@ -179,7 +180,7 @@ func (suite *ClientSuite) TestClientPostSendsRequestWithParams(c *gc.C) {
 	expectedResult := "expected:result"
 	fullURI := URI.String() + "?op=list"
 	params := url.Values{"test": {"123"}}
-	server := newSingleServingServer(fullURI, expectedResult, http.StatusOK)
+	server := newSingleServingServer(fullURI, expectedResult, http.StatusOK, -1)
 	defer server.Close()
 	client, err := NewAnonymousClient(server.URL, "1.0")
 	c.Assert(err, jc.ErrorIsNil)
@@ -221,7 +222,7 @@ func (suite *ClientSuite) TestClientPostSendsMultipartRequest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := "expected:result"
 	fullURI := URI.String() + "?op=add"
-	server := newSingleServingServer(fullURI, expectedResult, http.StatusOK)
+	server := newSingleServingServer(fullURI, expectedResult, http.StatusOK, -1)
 	defer server.Close()
 	client, err := NewAnonymousClient(server.URL, "1.0")
 	c.Assert(err, jc.ErrorIsNil)
@@ -242,7 +243,7 @@ func (suite *ClientSuite) TestClientPutSendsRequest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := "expected:result"
 	params := url.Values{"test": {"123"}}
-	server := newSingleServingServer(URI.String(), expectedResult, http.StatusOK)
+	server := newSingleServingServer(URI.String(), expectedResult, http.StatusOK, -1)
 	defer server.Close()
 	client, err := NewAnonymousClient(server.URL, "1.0")
 	c.Assert(err, jc.ErrorIsNil)
@@ -258,7 +259,7 @@ func (suite *ClientSuite) TestClientDeleteSendsRequest(c *gc.C) {
 	URI, err := url.Parse("/some/url")
 	c.Assert(err, jc.ErrorIsNil)
 	expectedResult := "expected:result"
-	server := newSingleServingServer(URI.String(), expectedResult, http.StatusOK)
+	server := newSingleServingServer(URI.String(), expectedResult, http.StatusOK, -1)
 	defer server.Close()
 	client, err := NewAnonymousClient(server.URL, "1.0")
 	c.Assert(err, jc.ErrorIsNil)

--- a/testing.go
+++ b/testing.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"time"
 )
 
 type singleServingServer struct {
@@ -18,7 +19,7 @@ type singleServingServer struct {
 
 // newSingleServingServer creates a single-serving test http server which will
 // return only one response as defined by the passed arguments.
-func newSingleServingServer(uri string, response string, code int) *singleServingServer {
+func newSingleServingServer(uri string, response string, code int, delay time.Duration) *singleServingServer {
 	var requestContent string
 	var requestHeader http.Header
 	var requested bool
@@ -36,6 +37,7 @@ func newSingleServingServer(uri string, response string, code int) *singleServin
 			errorMsg := fmt.Sprintf("Error 404: page not found (expected '%v', got '%v').", uri, request.URL.String())
 			http.Error(writer, errorMsg, http.StatusNotFound)
 		} else {
+			time.Sleep(delay)
 			writer.WriteHeader(code)
 			fmt.Fprint(writer, response)
 		}


### PR DESCRIPTION
Allows a user to pass a HTTP client in to the controller, to be used for making requests to the MAAS API. If no HTTP client is provided on controller creation, a new HTTP client is instantiated for each request (this is the same as previous behaviour).

This allows a user to configure TLS between self-signed servers, or to set request timeouts.

The changes are tested by forcing a timeout error on a request to the test server.