### PR TITLE
LP-2034014: retry on responses with status code equal to 409

### DIFF
--- a/client.go
+++ b/client.go
@@ -89,7 +89,7 @@ func (client Client) dispatchRequest(request *http.Request) ([]byte, error) {
 		// as instructed and retry the request.
 		if err != nil {
 			serverError, ok := errors.Cause(err).(ServerError)
-			if ok && serverError.StatusCode == http.StatusServiceUnavailable {
+			if ok && (serverError.StatusCode == http.StatusServiceUnavailable || serverError.StatusCode == http.StatusConflict) {
 				retryTimeInt, errConv := strconv.Atoi(serverError.Header.Get(RetryAfterHeaderName))
 				if errConv == nil {
 					select {

--- a/testing.go
+++ b/testing.go
@@ -69,7 +69,7 @@ func newFlakyServer(uri string, code int, nbFlakyResponses int) *flakyServer {
 			errorMsg := fmt.Sprintf("Error 404: page not found (expected '%v', got '%v').", uri, request.URL.String())
 			http.Error(writer, errorMsg, http.StatusNotFound)
 		} else if nbRequests <= nbFlakyResponses {
-			if code == http.StatusServiceUnavailable {
+			if code == http.StatusServiceUnavailable || code == http.StatusConflict {
 				writer.Header().Set("Retry-After", "0")
 			}
 			writer.WriteHeader(code)


### PR DESCRIPTION
This PR aims to retry on MAAS responses with status code equal to 409. 

In particular we observed that in some cases it is possible that the client calls MAAS endpoints in parallel and due to some MAAS internals the requests need to be remade by the clients. 

[Link to the original bug](https://bugs.launchpad.net/maas/+bug/2034014)

[Link to MAAS core merge proposal to add the `Retry-After` header in 409 responses](https://code.launchpad.net/~r00ta/maas/+git/maas/+merge/450867)