### PR TITLE
Add InsecureSkipVerify option to MAAS client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.sw[nop]
 example/[^.]*
+.vscode

--- a/controller.go
+++ b/controller.go
@@ -80,7 +80,7 @@ func newControllerWithVersion(baseURL, apiVersion, apiKey string, httpClient *ht
 	if err != nil {
 		return nil, errors.Errorf("bad version defined in supported versions: %q", apiVersion)
 	}
-	client, err := NewAuthenticatedClient(AddAPIVersionToURL(baseURL, apiVersion), apiKey)
+	client, err := NewAuthenticatedClient(AddAPIVersionToURL(baseURL, apiVersion), apiKey, false)
 	if err != nil {
 		// If the credentials aren't valid, return now.
 		if errors.IsNotValid(err) {
@@ -556,7 +556,7 @@ func (a *AllocateMachineArgs) notSubnets() []string {
 }
 
 // ConstraintMatches provides a way for the caller of AllocateMachine to determine
-//.how the allocated machine matched the storage and interfaces constraints specified.
+// .how the allocated machine matched the storage and interfaces constraints specified.
 // The labels that were used in the constraints are the keys in the maps.
 type ConstraintMatches struct {
 	// Interface is a mapping of the constraint label specified to the Interfaces
@@ -629,9 +629,9 @@ type ReleaseMachinesArgs struct {
 // ReleaseMachines implements Controller.
 //
 // Release multiple machines at once. Returns
-//  - BadRequestError if any of the machines cannot be found
-//  - PermissionError if the user does not have permission to release any of the machines
-//  - CannotCompleteError if any of the machines could not be released due to their current state
+//   - BadRequestError if any of the machines cannot be found
+//   - PermissionError if the user does not have permission to release any of the machines
+//   - CannotCompleteError if any of the machines could not be released due to their current state
 func (c *controller) ReleaseMachines(args ReleaseMachinesArgs) error {
 	params := NewURLParams()
 	params.MaybeAddMany("machines", args.SystemIDs)

--- a/example/live_example.go
+++ b/example/live_example.go
@@ -51,7 +51,7 @@ func main() {
 
 	// Create API server endpoint.
 	authClient, err := gomaasapi.NewAuthenticatedClient(
-		gomaasapi.AddAPIVersionToURL(apiURL, apiVersion), apiKey)
+		gomaasapi.AddAPIVersionToURL(apiURL, apiVersion), apiKey, false)
 	checkError(err)
 	maas := gomaasapi.NewMAAS(*authClient)
 

--- a/testservice.go
+++ b/testservice.go
@@ -44,7 +44,7 @@ func checkError(err error) {
 // by gomaasapi.NewMAAS().
 func NewTestMAAS(version string) *TestMAASObject {
 	server := NewTestServer(version)
-	authClient, err := NewAnonymousClient(server.URL, version)
+	authClient, err := NewAnonymousClient(server.URL, version, false)
 	checkError(err)
 	maas := NewMAAS(*authClient)
 	return &TestMAASObject{*maas, server}
@@ -663,7 +663,7 @@ func NewTestServer(version string) *TestServer {
 	}
 
 	newServer := httptest.NewServer(http.HandlerFunc(singleFile))
-	client, err := NewAnonymousClient(newServer.URL, "1.0")
+	client, err := NewAnonymousClient(newServer.URL, "1.0", false)
 	checkError(err)
 	server.Server = newServer
 	server.serveMux = serveMux


### PR DESCRIPTION
This PR:

- exposes the `InsecureSkipVerify` flag of `HTTPClient` to be set by functions that initializing maas api clients; both anonymous and authenticated.
- applies `go fmt` to the repo
- adds `.vscode` directory to git ignored files