### PR TITLE
LP-2039105: do not duplicate the oauth headers in case of retry

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -75,6 +75,6 @@ func (signer plainTextOAuthSigner) OAuthSign(request *http.Request) error {
 		authHeader = append(authHeader, fmt.Sprintf(`%s="%s"`, key, url.QueryEscape(value)))
 	}
 	strHeader := "OAuth " + strings.Join(authHeader, ", ")
-	request.Header.Add("Authorization", strHeader)
+	request.Header.Set("Authorization", strHeader)
 	return nil
 }


### PR DESCRIPTION
Bugfix for https://bugs.launchpad.net/maas/+bug/2039105. 

The bug is that in case of retry, the oauth headers are duplicated in the requests and MAAS nginx reject the request with 400. The fix is actually to use `http.Header.Set` instead of `http.Header.Add` in order to set or replace the "Authentication" header. 